### PR TITLE
Allow `Signal.sender()` to work regardless of importing from magicgui or Psygnal

### DIFF
--- a/magicgui/events.py
+++ b/magicgui/events.py
@@ -61,7 +61,7 @@ class SignalInstance(psygnal.SignalInstance):
         rem = []
         # allow receiver to query sender with Signal.current_emitter()
         with self._lock:
-            with Signal._emitting(self):
+            with Signal._emitting(self), psygnal.Signal._emitting(self):
                 for _slt in self._slots:
                     (slot, max_args) = _slt
                     if isinstance(slot, tuple):


### PR DESCRIPTION
with the deprecation override  of `psygnal.Signal` ... querying the source of the signal currently only works if you import `Signal` from magicgui. .. this fixes that.