### PR TITLE
fix bug in show_file_dialog

### DIFF
--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -1183,7 +1183,7 @@ def show_file_dialog(
     parent=None,
 ) -> str | None:
     show_dialog = QFILE_DIALOG_MODES[FileDialogMode(mode)]
-    if mode is FileDialogMode.EXISTING_DIRECTORY:
+    if FileDialogMode(mode) is FileDialogMode.EXISTING_DIRECTORY:
         result = show_dialog(parent, caption, start_path)
     else:
         result, _ = show_dialog(parent, caption, start_path, filter)


### PR DESCRIPTION
Hi guys,

first of all fantastic work to make python applications graphical user interfacing more and more.

I have used this to make my own GUI applications. I noticed that there is a very small bug in the show_file_dialog function.
It does not work for the directory mode, because the if condition is not correct. I fix this.

![Image_bug](https://user-images.githubusercontent.com/83079938/203525330-a58d0697-41a7-4197-9c76-7f4fe5231fe9.png)
