### PR TITLE
docs: attempting to simplify/clarify widget init docstrings

### DIFF
--- a/docs/api/bases.md
+++ b/docs/api/bases.md
@@ -1,13 +1,12 @@
-# magicgui.widgets._bases
+# magicgui.widgets.bases
 
 ```{eval-rst}
-.. currentmodule:: magicgui.widgets._bases
+.. currentmodule:: magicgui.widgets.bases
 
-.. automodule:: magicgui.widgets._bases
+.. automodule:: magicgui.widgets.bases
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Widget
    ValueWidget

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -6,7 +6,6 @@
 .. autosummary::
    :nosignatures:
    :template: autosummary/protocol-class.rst
-   :toctree: _autosummary
 
    WidgetProtocol
    ValueWidgetProtocol

--- a/docs/api/type_map.md
+++ b/docs/api/type_map.md
@@ -5,7 +5,6 @@
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    get_widget_class
    register_type

--- a/docs/api/widgets.md
+++ b/docs/api/widgets.md
@@ -8,7 +8,6 @@ Functions
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    create_widget
 
@@ -20,22 +19,21 @@ Value Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
-   Label
-   LineEdit
-   LiteralEvalLineEdit
-   Password
-   TextEdit
-   FileEdit
-   RangeEdit
-   SliceEdit
-   DateTimeEdit
-   DateEdit
-   TimeEdit
-   Table
-   QuantityEdit
-   EmptyWidget
+   magicgui.widgets.Label
+   magicgui.widgets.LineEdit
+   magicgui.widgets.LiteralEvalLineEdit
+   magicgui.widgets.Password
+   magicgui.widgets.TextEdit
+   magicgui.widgets.FileEdit
+   magicgui.widgets.RangeEdit
+   magicgui.widgets.SliceEdit
+   magicgui.widgets.DateTimeEdit
+   magicgui.widgets.DateEdit
+   magicgui.widgets.TimeEdit
+   magicgui.widgets.Table
+   magicgui.widgets.QuantityEdit
+   magicgui.widgets.EmptyWidget
 
 
 Button Widgets
@@ -43,7 +41,6 @@ Button Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    PushButton
    CheckBox
@@ -54,7 +51,6 @@ Ranged Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    SpinBox
    FloatSpinBox
@@ -64,7 +60,6 @@ Slider Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Slider
    FloatSlider
@@ -78,7 +73,6 @@ Categorical Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    ComboBox
    Select
@@ -89,7 +83,6 @@ Container Widgets
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Container
    FunctionGui

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book==0.13.0
+jupyter-book==0.13.1
 sphinx_material==0.0.35
 jupytext==1.13.8
 numpy

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -128,10 +128,7 @@ example, the `a_string` paremeter would be turned into a
 argument "`min`":
 ```
 
-```{code-cell} python
----
-:tags: [raises-exception]
----
+```python
 @magicgui(a_string={'min': 10})
 def whoops(a_string: str = 'Hi there'):
     ...

--- a/docs/usage/types_widgets.md
+++ b/docs/usage/types_widgets.md
@@ -52,7 +52,7 @@ def function(arg):
 
 Using the logic defined
 in the {mod}`magicgui.type_map` module, magicgui will select an appropriate
-{class}`~magicgui.widgets._bases.Widget` subclass to display the any given type
+{class}`~magicgui.widgets.Widget` subclass to display the any given type
 or type annotation. To see the default type of widget magicgui will for a given
 value, use the {func}`~magicgui.type_map.get_widget_class` function:
 

--- a/docs/usage/widget_overview.md
+++ b/docs/usage/widget_overview.md
@@ -119,7 +119,6 @@ following `ValueWidgets` track some `value`:
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Label
    LineEdit
@@ -158,7 +157,7 @@ following `ValueWidgets` track some `value`:
     accessed, the value provided here will be returned.  The bound value can be a
     callable, in which case `bound_value(self)` will be returned (i.e. your callback
     must accept a single parameter, which is this widget instance.). see
-    {meth}`ValueWidget.bind <magicgui.widgets._bases.value_widget.ValueWidget.bind>`
+    {meth}`ValueWidget.bind <magicgui.widgets.bases.ValueWidget.bind>`
     for details.
 ```
 
@@ -199,7 +198,6 @@ values, and a step size.  `RangedWidgets` include:
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    SpinBox
    FloatSpinBox
@@ -248,7 +246,6 @@ that additionally have an `orientation`, and a `readout`.
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Slider
    FloatSlider
@@ -292,7 +289,6 @@ container.show()
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    PushButton
    CheckBox
@@ -333,7 +329,6 @@ of valid choices.  They can be created from:
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    ComboBox
    RadioButtons
@@ -384,7 +379,6 @@ notable example of a `Container` is {class}`magicgui.widgets.FunctionGui`)
 
 .. autosummary::
    :nosignatures:
-   :toctree: _autosummary
 
    Container
    MainWindow

--- a/src/magicgui/type_map/_type_map.py
+++ b/src/magicgui/type_map/_type_map.py
@@ -14,14 +14,17 @@ from typing import (
     Any,
     Callable,
     DefaultDict,
+    Dict,
     ForwardRef,
     Iterator,
     Literal,
     Optional,
     Sequence,
     Set,
+    Tuple,
     Type,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -31,18 +34,16 @@ from typing_extensions import get_args, get_origin
 from magicgui import widgets
 from magicgui._type_resolution import resolve_single_type
 from magicgui._util import safe_issubclass
-from magicgui.types import (
-    PathLike,
-    ReturnCallback,
-    Undefined,
-    WidgetClass,
-    WidgetRef,
-    WidgetTuple,
-    _Undefined,
-)
+from magicgui.types import PathLike, ReturnCallback, Undefined, _Undefined
 from magicgui.widgets.protocols import WidgetProtocol, assert_protocol
 
 __all__: list[str] = ["register_type", "get_widget_class"]
+
+
+# redefining these here for the sake of sphinx autodoc forward refs
+WidgetClass = Union[Type[widgets.Widget], Type[WidgetProtocol]]
+WidgetRef = Union[str, WidgetClass]
+WidgetTuple = Tuple[WidgetRef, Dict[str, Any]]
 
 
 class MissingWidget(RuntimeError):

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -22,7 +22,15 @@ if TYPE_CHECKING:
     from magicgui.widgets.bases import CategoricalWidget, Widget  # noqa: F401
     from magicgui.widgets.protocols import WidgetProtocol
 
-#: A :class:`~magicgui.widgets._bases.Widget` class or a
+
+class ChoicesDict(TypedDict):
+    """Dict Type for setting choices in a categorical widget."""
+
+    choices: ChoicesIterable
+    key: Callable[[Any], str]
+
+
+#: A :class:`~magicgui.widgets.Widget` class or a
 #: :class:`~magicgui.widgets.protocols.WidgetProtocol`
 WidgetClass = Union[Type["Widget"], Type["WidgetProtocol"]]
 #: A generic reference to a :attr:`WidgetClass` as a string, or the class itself.
@@ -35,7 +43,7 @@ ChoicesIterable = Union[Iterable[Tuple[str, Any]], Iterable[Any]]
 #: a categorical widget and returns a :attr:`ChoicesIterable`.
 ChoicesCallback = Callable[["CategoricalWidget[Any]"], ChoicesIterable]
 #: The set of all valid types for widget ``choices``.
-ChoicesType = Union[EnumMeta, ChoicesIterable, ChoicesCallback, "ChoicesDict"]
+ChoicesType = Union[EnumMeta, ChoicesIterable, ChoicesCallback, ChoicesDict]
 #: A callback that may be registered for a given return annotation. When called, it will
 #: be provided an instance of a :class:`~magicgui.widgets.FunctionGui`, the result
 #: of the function that was called, and the return annotation itself.
@@ -57,13 +65,6 @@ class FileDialogMode(Enum):
     EXISTING_FILES = "rm"
     OPTIONAL_FILE = "w"
     EXISTING_DIRECTORY = "d"
-
-
-class ChoicesDict(TypedDict):
-    """Dict Type for setting choices in a categorical widget."""
-
-    choices: ChoicesIterable
-    key: Callable[[Any], str]
 
 
 class _Undefined:

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -154,7 +154,7 @@ class EmptyWidget(ValueWidget):
 
 
 @backend_widget
-class Label(ValueWidget):
+class Label(ValueWidget[str]):
     """A non-editable text display."""
 
 
@@ -169,7 +169,7 @@ class Password(ValueWidget[str]):
 
 
 @backend_widget
-class LiteralEvalLineEdit(ValueWidget):
+class LiteralEvalLineEdit(ValueWidget[str]):
     """A one-line text editor that evaluates strings as python literals."""
 
 
@@ -219,7 +219,7 @@ class FloatSpinBox(RangedWidget[float]):
 
 
 @backend_widget
-class ProgressBar(SliderWidget):
+class ProgressBar(SliderWidget[float]):
     """A progress bar widget."""
 
     def increment(self, val: float | None = None) -> None:
@@ -231,8 +231,8 @@ class ProgressBar(SliderWidget):
         self.value = self.get_value() - (val if val is not None else self.step)
 
     # overriding because at least some backends don't have a step value for ProgressBar
-    @property
-    def step(self) -> float | None:
+    @property  # type: ignore
+    def step(self) -> float:
         """Step size for widget values."""
         return self._step
 
@@ -242,12 +242,12 @@ class ProgressBar(SliderWidget):
 
 
 @backend_widget
-class Slider(SliderWidget):
+class Slider(SliderWidget[int]):
     """A slider widget to adjust an integer value within a range."""
 
 
 @backend_widget
-class FloatSlider(SliderWidget):
+class FloatSlider(SliderWidget[float]):
     """A slider widget to adjust an integer value within a range."""
 
 
@@ -609,8 +609,17 @@ class ListEdit(Container[ValueWidget[_V]]):
 
     Parameters
     ----------
+    value : Iterable, optional
+        The starting value for the widget.
+    layout : str, optional
+        The layout for the container.  must be one of ``{'horizontal',
+        'vertical'}``. by default "horizontal"
+    nullable : bool
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
     options: dict, optional
         Widget options of child widgets.
+    **kwargs : Any
+        All additional keyword arguments are passed to `Container` constructor.
     """
 
     def __init__(
@@ -844,13 +853,23 @@ class TupleEdit(Container[ValueWidget]):
 
     Parameters
     ----------
+    value : Iterable, optional
+        The starting value for the widget.
+    layout : str, optional
+        The layout for the container.  must be one of ``{'horizontal',
+        'vertical'}``. by default "horizontal"
+    nullable : bool
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
     options: dict, optional
         Widget options of child widgets.
+    **kwargs : Any
+        All additional keyword arguments are passed to `Container` constructor.
     """
 
     def __init__(
         self,
         value: Iterable[_V] | _Undefined = Undefined,
+        *,
         layout: str = "horizontal",
         nullable: bool = False,
         options: dict | None = None,

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -10,7 +10,6 @@ import datetime
 import inspect
 import math
 import os
-import sys
 from pathlib import Path
 from typing import (
     Any,
@@ -30,7 +29,6 @@ from typing import (
 )
 from weakref import ref
 
-from docstring_parser import DocstringParam, parse
 from typing_extensions import get_args, get_origin
 
 from magicgui._type_resolution import resolve_single_type
@@ -54,81 +52,12 @@ from magicgui.widgets.bases import (
 )
 from magicgui.widgets.bases._mixins import _OrientationMixin, _ReadOnlyMixin
 
-BUILDING_DOCS = sys.argv[-2:] == ["build", "docs"]
+from ._docs_sigs import merge_super_sigs
+
 WidgetVar = TypeVar("WidgetVar", bound=Widget)
 WidgetTypeVar = TypeVar("WidgetTypeVar", bound=Type[Widget])
-C = TypeVar("C", bound=type)
 _V = TypeVar("_V")
-
-
-def _param_list_to_str(param_list: list[DocstringParam]) -> str:
-    """Format Parameters section for numpy docstring from list of tuples."""
-    out = []
-    out += ["Parameters", len("Parameters") * "-"]
-    for param in param_list:
-        parts = []
-        if param.arg_name:
-            parts.append(param.arg_name)
-        if param.type_name:
-            parts.append(param.type_name)
-        if not parts:
-            continue
-        out += [" : ".join(parts)]
-        if param.description and param.description.strip():
-            out += [" " * 4 + line for line in param.description.split("\n")]
-    out += [""]
-    return "\n".join(out)
-
-
-def merge_super_sigs(
-    cls: C, exclude: Sequence[str] = ("widget_type", "kwargs", "args", "kwds", "extra")
-) -> C:
-    """Merge the signature and kwarg docs from all superclasses, for clearer docs.
-
-    Parameters
-    ----------
-    cls : Type
-        The class being modified
-    exclude : tuple, optional
-        A list of parameter names to excluded from the merged docs/signature,
-        by default ("widget_type", "kwargs", "args", "kwds")
-
-    Returns
-    -------
-    cls : Type
-        The modified class (can be used as a decorator)
-    """
-    params = {}
-    param_docs: list[DocstringParam] = []
-    for sup in reversed(inspect.getmro(cls)):
-        try:
-            sig = inspect.signature(sup.__init__)  # type: ignore
-        # in some environments `object` or `abc.ABC` will raise ValueError here
-        except ValueError:
-            continue
-        for name, param in sig.parameters.items():
-            if name in exclude:
-                continue
-            params[name] = param
-
-        param_docs += parse(getattr(sup, "__doc__", "")).params
-
-    # sphinx_autodoc_typehints isn't removing the type annotations from the signature
-    # so we do it manually when building documentation.
-    if BUILDING_DOCS:
-        params = {
-            k: v.replace(annotation=inspect.Parameter.empty) for k, v in params.items()
-        }
-
-    cls.__init__.__signature__ = inspect.Signature(  # type: ignore
-        sorted(params.values(), key=lambda x: x.kind)
-    )
-    param_docs = [p for p in param_docs if p.arg_name not in exclude]
-    cls.__doc__ = (cls.__doc__ or "").split("Parameters")[0].rstrip() + "\n\n"
-    cls.__doc__ += _param_list_to_str(param_docs)
-    # this makes docs linking work... but requires that all of these be in __init__
-    cls.__module__ = "magicgui.widgets"
-    return cls
+TV = TypeVar("TV", bound=Union[datetime.time, datetime.timedelta])
 
 
 @overload
@@ -259,9 +188,6 @@ class DateEdit(ValueWidget[datetime.date]):
     """A widget for editing dates."""
 
 
-TV = TypeVar("TV", bound=Union[datetime.time, datetime.timedelta])
-
-
 @backend_widget
 class TimeEdit(ValueWidget[TV]):
     """A widget for editing times."""
@@ -326,12 +252,12 @@ class FloatSlider(SliderWidget):
 
 
 @backend_widget
-class RangeSlider(MultiValuedSliderWidget[Tuple[int, int]]):
+class RangeSlider(MultiValuedSliderWidget):
     """A slider widget to adjust a range between two integer values within a range."""
 
 
 @backend_widget
-class FloatRangeSlider(MultiValuedSliderWidget[Tuple[float, float]]):
+class FloatRangeSlider(MultiValuedSliderWidget):
     """A slider widget to adjust a range defined by two float values within a range."""
 
 

--- a/src/magicgui/widgets/_docs_sigs.py
+++ b/src/magicgui/widgets/_docs_sigs.py
@@ -20,31 +20,23 @@ def _param_list_to_str(
         if param.arg_name:
             parts.append(param.arg_name)
 
+        type_name = param.type_name or "Any"
         # temporary hacky approach to inject the widget specific type into docstrings
-        if param.arg_name == "value":
-            if valtype is not None and (
-                not param.type_name or param.type_name == "Any"
-            ):
-                if isinstance(valtype, TypeVar):
-                    if valtype.__bound__:
-                        if valtype.__bound__.__origin__ is Union:
-                            c = " | ".join(
-                                [str(c.__name__) for c in valtype.__bound__.__args__]
-                            )
-                            parts.append(c)
-                    elif valtype.__constraints__:
-                        c = " | ".join(
-                            [str(c.__name__) for c in valtype.__constraints__]
+        if param.arg_name == "value" and valtype is not None and (type_name == "Any"):
+            if isinstance(valtype, TypeVar):
+                if getattr(valtype, "__bound__", None):
+                    if valtype.__bound__.__origin__ is Union:
+                        type_name = " | ".join(
+                            [str(c.__name__) for c in valtype.__bound__.__args__]
                         )
-                        parts.append(c)
-                    else:
-                        parts.append("Any")
-                else:
-                    parts.append(valtype.__name__)
-            elif param.type_name:
-                parts.append(param.type_name)
-        elif param.type_name:
-            parts.append(param.type_name)
+                elif getattr(valtype, "__constraints__", None):
+                    type_name = " | ".join(
+                        [str(c.__name__) for c in valtype.__constraints__]
+                    )
+            elif hasattr(valtype, "__name__"):
+                type_name = valtype.__name__
+        if type_name:
+            parts.append(type_name)
 
         if not parts:
             continue

--- a/src/magicgui/widgets/_docs_sigs.py
+++ b/src/magicgui/widgets/_docs_sigs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import sys
 from typing import Sequence, TypeVar, Union

--- a/src/magicgui/widgets/_docs_sigs.py
+++ b/src/magicgui/widgets/_docs_sigs.py
@@ -1,0 +1,80 @@
+import inspect
+import sys
+from typing import Sequence, TypeVar
+
+from docstring_parser import DocstringParam, parse
+
+C = TypeVar("C", bound=type)
+
+
+def _param_list_to_str(param_list: list[DocstringParam]) -> str:
+    """Format Parameters section for numpy docstring from list of tuples."""
+    out = []
+    out += ["Parameters", len("Parameters") * "-"]
+    for param in param_list:
+        parts = []
+        if param.arg_name:
+            parts.append(param.arg_name)
+        if param.type_name:
+            parts.append(param.type_name)
+        if not parts:
+            continue
+        out += [" : ".join(parts)]
+        if param.description and param.description.strip():
+            out += [" " * 4 + line for line in param.description.split("\n")]
+    out += [""]
+    return "\n".join(out)
+
+
+def merge_super_sigs(
+    cls: C, exclude: Sequence[str] = ("widget_type", "kwargs", "args", "kwds", "extra")
+) -> C:
+    """Merge the signature and kwarg docs from all superclasses, for clearer docs.
+
+    Parameters
+    ----------
+    cls : Type
+        The class being modified
+    exclude : tuple, optional
+        A list of parameter names to excluded from the merged docs/signature,
+        by default ("widget_type", "kwargs", "args", "kwds")
+
+    Returns
+    -------
+    cls : Type
+        The modified class (can be used as a decorator)
+    """
+    params = {}
+    param_docs: list[DocstringParam] = []
+    for sup in inspect.getmro(cls):
+        try:
+            sig = inspect.signature(sup.__init__)  # type: ignore
+        # in some environments `object` or `abc.ABC` will raise ValueError here
+        except ValueError:
+            continue
+        for name, param in sig.parameters.items():
+            if name in exclude:
+                continue
+            params[name] = param
+
+        docstring = getattr(sup, "__doc__", "")
+        param_docs += parse(docstring).params
+        if "Parameters" in docstring:
+            break
+
+    # sphinx_autodoc_typehints isn't removing the type annotations from the signature
+    # so we do it manually when building documentation.
+    if sys.argv[-2:] == ["build", "docs"]:
+        params = {
+            k: v.replace(annotation=inspect.Parameter.empty) for k, v in params.items()
+        }
+
+    cls.__init__.__signature__ = inspect.Signature(  # type: ignore
+        sorted(params.values(), key=lambda x: x.kind)
+    )
+    param_docs = [p for p in param_docs if p.arg_name not in exclude]
+    cls.__doc__ = (cls.__doc__ or "").split("Parameters")[0].rstrip() + "\n\n"
+    cls.__doc__ += _param_list_to_str(param_docs)
+    # this makes docs linking work... but requires that all of these be in __init__
+    cls.__module__ = "magicgui.widgets"
+    return cls

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -1,7 +1,10 @@
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any, Callable
 
 from psygnal import Signal, SignalInstance
 
+from magicgui.types import Undefined, _Undefined
 from magicgui.widgets import protocols
 
 from ._value_widget import ValueWidget
@@ -12,26 +15,47 @@ class ButtonWidget(ValueWidget[bool]):
 
     Parameters
     ----------
+    value : Any, optional
+        The starting value for the widget.
     text : str, optional
         The text to display on the button. If not provided, will use ``name``.
+    bind : Any, optional
+        A value or callback to bind this widget, then whenever `widget.value` is
+        accessed, the value provided here will be returned.  ``value`` can be a
+        callable, in which case ``value(self)`` will be returned (i.e. your callback
+        must accept a single parameter, which is this widget instance.).
+    nullable : bool, optional
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
+    **base_widget_kwargs : Any
+        All additional keyword arguments are passed to the base `Widget` constructor.
     """
 
     _widget: protocols.ButtonWidgetProtocol
     changed = Signal(object)
 
-    def __init__(self, text: Optional[str] = None, **value_widget_kwargs: Any) -> None:
-        if text and value_widget_kwargs.get("label"):
+    def __init__(
+        self,
+        value: bool | _Undefined = Undefined,
+        *,
+        text: str | None = None,
+        bind: bool | Callable[[ValueWidget], bool] | _Undefined = Undefined,
+        nullable: bool = False,
+        **base_widget_kwargs: Any,
+    ) -> None:
+        if text and base_widget_kwargs.get("label"):
             from warnings import warn
 
             warn(
                 "'text' and 'label' are synonymous for button widgets. To suppress this"
                 " warning, only provide one of the two kwargs."
             )
-        text = text or value_widget_kwargs.get("label")
+        text = text or base_widget_kwargs.get("label")
         # TODO: make a backend hook that lets backends inject their optional API
         # ipywidgets button texts are called descriptions
-        text = text or value_widget_kwargs.pop("description", None)
-        super().__init__(**value_widget_kwargs)
+        text = text or base_widget_kwargs.pop("description", None)
+        super().__init__(
+            value=value, bind=bind, nullable=nullable, **base_widget_kwargs
+        )
         self.text = (text or self.name).replace("_", " ")
 
     @property

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -15,8 +15,8 @@ class ButtonWidget(ValueWidget[bool]):
 
     Parameters
     ----------
-    value : Any, optional
-        The starting value for the widget.
+    value : bool
+        The starting state of the widget.
     text : str, optional
         The text to display on the button. If not provided, will use ``name``.
     bind : Any, optional
@@ -27,7 +27,8 @@ class ButtonWidget(ValueWidget[bool]):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.ButtonWidgetProtocol

--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -10,12 +10,12 @@ from ._value_widget import T, ValueWidget
 
 
 class CategoricalWidget(ValueWidget[T]):
-    """Widget with a value and choices, Wraps CategoricalWidgetProtocol.
+    """Widget with a value and choices.  Wraps CategoricalWidgetProtocol.
 
     Parameters
     ----------
     value : Any, optional
-        The starting value for the widget.
+        The initially selected choice.
     choices : Enum, Iterable, or Callable
         Available choices displayed in the combo box.
     bind : Any, optional
@@ -26,7 +26,8 @@ class CategoricalWidget(ValueWidget[T]):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.CategoricalWidgetProtocol

--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum, EnumMeta
 from typing import Any, Callable, cast
 
-from magicgui.types import ChoicesType
+from magicgui.types import ChoicesType, Undefined, _Undefined
 from magicgui.widgets import protocols
 
 from ._value_widget import T, ValueWidget
@@ -14,8 +14,19 @@ class CategoricalWidget(ValueWidget[T]):
 
     Parameters
     ----------
+    value : Any, optional
+        The starting value for the widget.
     choices : Enum, Iterable, or Callable
         Available choices displayed in the combo box.
+    bind : Any, optional
+        A value or callback to bind this widget, then whenever `widget.value` is
+        accessed, the value provided here will be returned.  ``value`` can be a
+        callable, in which case ``value(self)`` will be returned (i.e. your callback
+        must accept a single parameter, which is this widget instance.).
+    nullable : bool, optional
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
+    **base_widget_kwargs : Any
+        All additional keyword arguments are passed to the base `Widget` constructor.
     """
 
     _widget: protocols.CategoricalWidgetProtocol
@@ -24,14 +35,20 @@ class CategoricalWidget(ValueWidget[T]):
 
     def __init__(
         self,
+        value: T | _Undefined = Undefined,
         choices: ChoicesType = (),
+        *,
         allow_multiple: bool | None = None,
-        **kwargs: Any,
+        bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
+        nullable: bool = False,
+        **base_widget_kwargs: Any,
     ) -> None:
         if allow_multiple is not None:
             self._allow_multiple = allow_multiple
         self._default_choices = choices
-        super().__init__(**kwargs)
+        super().__init__(
+            value=value, bind=bind, nullable=nullable, **base_widget_kwargs
+        )
 
     def _post_init(self) -> None:
         super()._post_init()

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -58,19 +58,22 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
 
     Parameters
     ----------
+    widgets : Sequence[Widget], optional
+        A sequence of widgets with which to intialize the container, by default
+        ``None``.
     layout : str, optional
         The layout for the container.  must be one of ``{'horizontal',
         'vertical'}``. by default "vertical"
     scrollable : bool, optional
         Whether to enable scroll bars or not. If enabled, scroll bars will
         only appear along the layout direction, not in both directions.
-    widgets : Sequence[Widget], optional
-        A sequence of widgets with which to intialize the container, by default
-        ``None``.
     labels : bool, optional
         Whether each widget should be shown with a corresponding Label widget to the
         left, by default ``True``.  Note: the text for each widget defaults to
         ``widget.name``, but can be overriden by setting ``widget.label``.
+    **base_widget_kwargs : Any
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     changed = Signal(object)
@@ -84,15 +87,17 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
         layout: str = "vertical",
         scrollable: bool = False,
         labels: bool = True,
-        **kwargs: Any,
+        **base_widget_kwargs: Any,
     ) -> None:
         self._list: list[WidgetVar] = []
         self._labels = labels
         self._layout = layout
         self._scrollable = scrollable
-        kwargs.setdefault("backend_kwargs", {})
-        kwargs["backend_kwargs"].update({"layout": layout, "scrollable": scrollable})
-        super().__init__(**kwargs)
+        base_widget_kwargs.setdefault("backend_kwargs", {})
+        base_widget_kwargs["backend_kwargs"].update(
+            {"layout": layout, "scrollable": scrollable}
+        )
+        super().__init__(**base_widget_kwargs)
         self.extend(widgets)
         self.parent_changed.connect(self.reset_choices)
         self._initialized = True

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -79,9 +79,10 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
 
     def __init__(
         self,
+        widgets: Sequence[WidgetVar] = (),
+        *,
         layout: str = "vertical",
         scrollable: bool = False,
-        widgets: Sequence[WidgetVar] = (),
         labels: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -38,7 +38,8 @@ class RangedWidget(ValueWidget[T]):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.RangedWidgetProtocol
@@ -213,7 +214,8 @@ class TransformedRangedWidget(RangedWidget[float], ABC):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.RangedWidgetProtocol

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import builtins
 from abc import ABC, abstractmethod
 from math import ceil, log10
@@ -44,9 +46,10 @@ class RangedWidget(ValueWidget[T]):
     def __init__(
         self,
         value: T | _Undefined = Undefined,
-        min: Union[float, _Undefined] = Undefined,
-        max: Union[float, _Undefined] = Undefined,
-        step: Union[float, _Undefined, None] = Undefined,
+        *,
+        min: float | _Undefined = Undefined,
+        max: float | _Undefined = Undefined,
+        step: float | _Undefined | None = Undefined,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
         **base_widget_kwargs: Any,
@@ -218,6 +221,7 @@ class TransformedRangedWidget(RangedWidget[float], ABC):
     def __init__(
         self,
         value: T | _Undefined = Undefined,
+        *,
         min: float = 0,
         max: float = 100,
         min_pos: int = 0,

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -11,7 +11,7 @@ from magicgui.widgets import protocols
 
 from ._value_widget import ValueWidget
 
-T = TypeVar("T", int, float, Tuple[int | float, ...])
+T = TypeVar("T", int, float, Tuple[Union[int, float], ...])
 DEFAULT_MIN = 0.0
 DEFAULT_MAX = 1000.0
 

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Union
+from typing import Any, Callable, Tuple, Union
 
 from magicgui.types import Undefined, _Undefined
 from magicgui.widgets import protocols
@@ -50,9 +50,9 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
         self,
         value: T | _Undefined = Undefined,
         *,
-        min: Union[float, _Undefined] = Undefined,
-        max: Union[float, _Undefined] = Undefined,
-        step: Union[float, _Undefined, None] = Undefined,
+        min: float | _Undefined = Undefined,
+        max: float | _Undefined = Undefined,
+        step: float | _Undefined | None = Undefined,
         orientation: str = "horizontal",
         readout: bool = True,
         tracking: bool = True,
@@ -112,7 +112,7 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
 
 
 class MultiValuedSliderWidget(
-    MultiValueRangedWidget[tuple[int | float, ...]], SliderWidget
+    MultiValueRangedWidget[Tuple[Union[int, float], ...]], SliderWidget
 ):
     """Slider widget that expects a iterable value."""
 

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -46,6 +46,7 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
     def __init__(
         self,
         value: T | _Undefined = Undefined,
+        *,
         min: Union[float, _Undefined] = Undefined,
         max: Union[float, _Undefined] = Undefined,
         step: Union[float, _Undefined, None] = Undefined,

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -38,7 +38,8 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.SliderWidgetProtocol

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -1,10 +1,10 @@
-from typing import Any, Sequence, TypeVar
+from typing import Any, Callable, Union
 
+from magicgui.types import Undefined, _Undefined
 from magicgui.widgets import protocols
 
 from ._mixins import _OrientationMixin
-from ._ranged_widget import MultiValueRangedWidget, RangedWidget
-from ._value_widget import T
+from ._ranged_widget import MultiValueRangedWidget, RangedWidget, T
 
 
 class SliderWidget(RangedWidget[T], _OrientationMixin):
@@ -12,6 +12,15 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
 
     Parameters
     ----------
+    value : Any, optional
+        The starting value for the widget.
+    min : float, optional
+        The minimum allowable value, by default 0 (or `value` if `value` is less than 0)
+    max : float, optional
+        The maximum allowable value, by default 999 (or `value` if `value` is greater
+        than 999)
+    step : float, optional
+        The step size for incrementing the value, by default adaptive step is used
     orientation : str, {'horizontal', 'vertical'}
         The orientation for the slider, by default "horizontal"
     readout : bool, optional
@@ -21,19 +30,45 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
         signal while the slider is being dragged. If tracking is disabled,
         the slider emits the `changed` signal only after the user releases
         the slider.
+    bind : Any, optional
+        A value or callback to bind this widget, then whenever `widget.value` is
+        accessed, the value provided here will be returned.  ``value`` can be a
+        callable, in which case ``value(self)`` will be returned (i.e. your callback
+        must accept a single parameter, which is this widget instance.).
+    nullable : bool, optional
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
+    **base_widget_kwargs : Any
+        All additional keyword arguments are passed to the base `Widget` constructor.
     """
 
     _widget: protocols.SliderWidgetProtocol
 
     def __init__(
         self,
+        value: T | _Undefined = Undefined,
+        min: Union[float, _Undefined] = Undefined,
+        max: Union[float, _Undefined] = Undefined,
+        step: Union[float, _Undefined, None] = Undefined,
         orientation: str = "horizontal",
         readout: bool = True,
         tracking: bool = True,
-        **kwargs: Any,
+        bind: T | Callable[[protocols.ValueWidgetProtocol], T] | _Undefined = Undefined,
+        nullable: bool = False,
+        **base_widget_kwargs: Any,
     ) -> None:
-        kwargs["backend_kwargs"] = {"readout": readout, "orientation": orientation}
-        super().__init__(**kwargs)
+        base_widget_kwargs["backend_kwargs"] = {
+            "readout": readout,
+            "orientation": orientation,
+        }
+        super().__init__(
+            value=value,  # type: ignore
+            min=min,
+            max=max,
+            step=step,
+            bind=bind,  # type: ignore
+            nullable=nullable,
+            **base_widget_kwargs,
+        )
         self.readout = readout
         self.tracking = tracking
 
@@ -72,10 +107,9 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
         self._widget._mgui_set_readout_visibility(value)
 
 
-TupleT = TypeVar("TupleT", bound=Sequence)
-
-
-class MultiValuedSliderWidget(MultiValueRangedWidget[TupleT], SliderWidget):
+class MultiValuedSliderWidget(
+    MultiValueRangedWidget[tuple[int | float, ...]], SliderWidget
+):
     """Slider widget that expects a iterable value."""
 
     _widget: protocols.SliderWidgetProtocol

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Union
 
 from magicgui.types import Undefined, _Undefined

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -26,7 +26,9 @@ class ValueWidget(Widget, Generic[T]):
         callable, in which case ``value(self)`` will be returned (i.e. your callback
         must accept a single parameter, which is this widget instance.).
     nullable : bool, optional
-        If `True`, the widget will accepts `None` as a valid value, by default False.
+        If `True`, the widget will accepts `None` as a valid value, by default `False`.
+    **base_widget_kwargs : Any
+        All additional keyword arguments are passed to the base `Widget` constructor.
     """
 
     _widget: protocols.ValueWidgetProtocol

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -28,7 +28,8 @@ class ValueWidget(Widget, Generic[T]):
     nullable : bool, optional
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
-        All additional keyword arguments are passed to the base `Widget` constructor.
+        All additional keyword arguments are passed to the base
+        :class:`~magicgui.widgets.Widget` constructor.
     """
 
     _widget: protocols.ValueWidgetProtocol

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -38,6 +38,7 @@ class ValueWidget(Widget, Generic[T]):
     def __init__(
         self,
         value: T | _Undefined = Undefined,
+        *,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
         **base_widget_kwargs: Any,


### PR DESCRIPTION
The widget constructor docstrings are very hard to read, cause there are too many parameters, and they're in the wrong order.  (but, it would also be awful to manually construct them for each widget).  This tries to improve the presentation a bit by moving to a "compromise" where the first widget in the mro that has a `Parameters` field has to be responsible for documenting everything.  since _most_ widgets don't actually have an init, that works well for most cases