### PR TITLE
Fix typos and add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,9 @@ repos:
     rev: v2.2.2
     hooks:
       - id: codespell
+        exclude: CHANGELOG.md
+        stages:
+          - "manual"
 
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
-    hooks:
-      - id: codespell
-        exclude: CHANGELOG.md
-        stages:
-          - "manual"
-
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
@@ -45,3 +37,13 @@ repos:
         additional_dependencies:
           - numpy
           - psygnal
+
+  # manual hooks
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        exclude: CHANGELOG.md
+        stages:
+          - "manual"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 **Implemented enhancements:**
 
-- Enable option to raise exception if magicgui cannot determine widget for provided value/annotation [\#476](https://github.com/pyapp-kit/magicgui/pull/476) ([Czaki](https://github.com/Czaki))
+- Enable option to raise excpetion if magicgui cannot determine widget for provided value/annotation [\#476](https://github.com/pyapp-kit/magicgui/pull/476) ([Czaki](https://github.com/Czaki))
 
 **Documentation:**
 
@@ -273,7 +273,7 @@
 
 **Documentation:**
 
-- adds waveform generator example [\#322](https://github.com/pyapp-kit/magicgui/pull/322) ([glyg](https://github.com/glyg))
+- adds waveform generator exemple [\#322](https://github.com/pyapp-kit/magicgui/pull/322) ([glyg](https://github.com/glyg))
 - add example of adding mpl FigureCanvas  to widget [\#321](https://github.com/pyapp-kit/magicgui/pull/321) ([tlambert03](https://github.com/tlambert03))
 
 ## [v0.3.3](https://github.com/pyapp-kit/magicgui/tree/v0.3.3) (2021-11-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 **Implemented enhancements:**
 
-- Enable option to raise excpetion if magicgui cannot determine widget for provided value/annotation [\#476](https://github.com/pyapp-kit/magicgui/pull/476) ([Czaki](https://github.com/Czaki))
+- Enable option to raise exception if magicgui cannot determine widget for provided value/annotation [\#476](https://github.com/pyapp-kit/magicgui/pull/476) ([Czaki](https://github.com/Czaki))
 
 **Documentation:**
 
@@ -273,7 +273,7 @@
 
 **Documentation:**
 
-- adds waveform generator exemple [\#322](https://github.com/pyapp-kit/magicgui/pull/322) ([glyg](https://github.com/glyg))
+- adds waveform generator example [\#322](https://github.com/pyapp-kit/magicgui/pull/322) ([glyg](https://github.com/glyg))
 - add example of adding mpl FigureCanvas  to widget [\#321](https://github.com/pyapp-kit/magicgui/pull/321) ([tlambert03](https://github.com/tlambert03))
 
 ## [v0.3.3](https://github.com/pyapp-kit/magicgui/tree/v0.3.3) (2021-11-08)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ static analysis tools to prevent errors from being introduced into the codebase:
 
 - [black](https://github.com/psf/black) - code formatting
 - [ruff](https://github.com/charliermarsh/ruff) - linting
-- [mypy](http://mypy-lang.org/) - static type anaylsis
+- [mypy](http://mypy-lang.org/) - static type analysis
 - [codecov](https://codecov.io/) - test coverage
 
 To prevent continuous integration failures when contributing, please consider

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -123,7 +123,7 @@ add.show()
 ```{caution}
 The keys in the parameter-specific options dict must be valid arguments
 for the corresponding widget type from {mod}`magicgui.widgets`.  In this
-example, the `a_string` paremeter would be turned into a
+example, the `a_string` parameter would be turned into a
 {class}`~magicgui.widgets.LineEdit` widget, which does not take an
 argument "`min`":
 ```

--- a/docs/usage/direct_api.md
+++ b/docs/usage/direct_api.md
@@ -45,7 +45,7 @@ container.show()
 
 Note, {class}`~magicgui.widgets.Container` widgets are subclassed from python's
 {class}`collections.abc.MutableSequence`, so they behave like a basic python
-list.  You can `append`, `instert`, `pop` widgets as you would with a regular
+list.  You can `append`, `insert`, `pop` widgets as you would with a regular
 list:
 
 ```python

--- a/docs/usage/main_window.md
+++ b/docs/usage/main_window.md
@@ -40,4 +40,4 @@ Running this function will show a GUI with a top app menu bar containing a singl
 
 This can be very helpful when your tool's functionality is not completely obvious at first glance, or when a few different user-enabled flags may interact in non-trivial ways. Alongside the tooltips for each parameter (which magicgui automatically generates) the GUI will be as well-documented as your code is.
 
-A runnable example which uses the HTML capabilties of this feature can be found in the github repository at [examples/main_window.py](https://github.com/pyapp-kit/magicgui/blob/main/examples/main_window.py).
+A runnable example which uses the HTML capabilities of this feature can be found in the github repository at [examples/main_window.py](https://github.com/pyapp-kit/magicgui/blob/main/examples/main_window.py).

--- a/docs/usage/widget_overview.md
+++ b/docs/usage/widget_overview.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # Widget Overview
 
-All indiviual graphical elements in `magicgui` are "widgets", and all widgets
+All individual graphical elements in `magicgui` are "widgets", and all widgets
 are instances of {class}`magicgui.widgets.Widget`.  Widgets may be created
 directly:
 
@@ -410,7 +410,7 @@ notable example of a `Container` is {class}`magicgui.widgets.FunctionGui`)
   - *bool, optional**
   - Whether each widget should be shown with a corresponding `Label` widget to the
     left, by default `True`.  Note: the text for each widget defaults to
-    `widget.name`, but can be overriden by setting `widget.label`.
+    `widget.name`, but can be overridden by setting `widget.label`.
 ```
 
 ## `@magicgui`

--- a/examples/napari_forward_refs.py
+++ b/examples/napari_forward_refs.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def subtract_background(
     data: "napari.types.ImageData", background: int = 50
 ) -> "napari.types.ImageData":
-    """Subtract a contstant from the data."""
+    """Subtract a constant from the data."""
     if data:
         return data - background
 

--- a/examples/waveform.py
+++ b/examples/waveform.py
@@ -23,8 +23,8 @@ Time = Annotated[float, {"min": 0.01, "max": 100.0}]
 class Signal:
     """Constructs a 1D signal
 
-    As is, this class is not very usefull, but one could add callbacks
-    or more functionnality here
+    As is, this class is not very useful, but one could add callbacks
+    or more functionality here
 
     Parameters
     ----------

--- a/src/magicgui/_util.py
+++ b/src/magicgui/_util.py
@@ -27,7 +27,7 @@ def debounce(*, wait: float = 0.2) -> Callable[[Callable[P, T]], Callable[P, T |
 
 
 def debounce(function: Callable[P, T] | None = None, wait: float = 0.2) -> Callable:
-    """Postpone function call until `wait` seconds since last invokation."""
+    """Postpone function call until `wait` seconds since last invocation."""
 
     def decorator(fn: Callable[P, T]) -> Callable[P, T | None]:
         from threading import Timer

--- a/src/magicgui/widgets/bases/__init__.py
+++ b/src/magicgui/widgets/bases/__init__.py
@@ -35,7 +35,7 @@ pattern is as follows:
 These widgets are unlikely to be instantiated directly, (unless you're creating a custom
 widget that implements one of the WidgetProtocols... as the backed widgets do).
 Instead, one will usually instantiate the widgets in :mod:`magicgui.widgets._concrete`
-which are all available direcly in the :mod:`magicgui.widgets` namespace.
+which are all available directly in the :mod:`magicgui.widgets` namespace.
 
 The :func:`~magicgui.widgets.create_widget` factory function may be used to
 create a widget subclass appropriate for the arguments passed (such as "value" or

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -52,14 +52,14 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
     as default values) is accessible with the :meth:`~ContainerWidget.__signature__`
     method (or by using :func:`inspect.signature` from the standard library)
 
-    For a ``ContainerWidget`` sublcass that is tightly coupled to a specific function
+    For a ``ContainerWidget`` subclass that is tightly coupled to a specific function
     signature (as in the "classic" magicgui decorator), see
     :class:`~magicgui.widgets.FunctionGui`.
 
     Parameters
     ----------
     widgets : Sequence[Widget], optional
-        A sequence of widgets with which to intialize the container, by default
+        A sequence of widgets with which to initialize the container, by default
         ``None``.
     layout : str, optional
         The layout for the container.  must be one of ``{'horizontal',
@@ -70,7 +70,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
     labels : bool, optional
         Whether each widget should be shown with a corresponding Label widget to the
         left, by default ``True``.  Note: the text for each widget defaults to
-        ``widget.name``, but can be overriden by setting ``widget.label``.
+        ``widget.name``, but can be overridden by setting ``widget.label``.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
         :class:`~magicgui.widgets.Widget` constructor.

--- a/src/magicgui/widgets/bases/_create_widget.py
+++ b/src/magicgui/widgets/bases/_create_widget.py
@@ -59,7 +59,7 @@ def create_widget(
     options : dict, optional
         Dict of options to pass to the Widget constructor, by default dict()
     is_result : boolean, optional
-        Whether the widget belongs to an input or an output. By defult, an input
+        Whether the widget belongs to an input or an output. By default, an input
         is assumed.
     raise_on_unknown : bool, optional
         Raise exception if no widget is found for the given type, by default True

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -366,7 +366,7 @@ def test_get_choices_raises():
     ids=["with-labels", "no-labels"],
 )
 def test_add_at_position(labels):
-    """Test that adding widghet with position option puts widget in the right place."""
+    """Test that adding widget with position option puts widget in the right place."""
 
     def func(a=1, b=2, c=3):
         pass
@@ -674,7 +674,7 @@ def test_no_tooltips_from_numpydoc():
 
 def test_only_some_tooltips_from_numpydoc():
     """Test that we can still show some tooltips with ``tooltips=False``."""
-    # tooltips=False, means docstrings wont be parsed at all, but tooltips
+    # tooltips=False, means docstrings won't be parsed at all, but tooltips
     # can still be manually provided.
     @magicgui(tooltips=False, y={"tooltip": "Still want a tooltip"})
     def func(x: int, y: str = "hi"):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -71,11 +71,11 @@ def test_constructor():
     assert Table([1, 2]).shape == (2, 1)  # single list is interpreted as column
     assert Table([[1, 2]]).shape == (1, 2)  # nested lists are rows
 
-    # aruments to constructor override those in a dict value
+    # arguments to constructor override those in a dict value
     t = Table(_TABLE_DATA["dict"], columns=("x", "y", "z"))
     assert t.column_headers == ("x", "y", "z")
 
-    # data and headers can be provided seperately
+    # data and headers can be provided separately
     t = Table([[1, 2, 3], [4, 5, 6]], columns=["col_1", "col_2", "col_3"])
     assert dict(t) == _TABLE_DATA["list"]
     # or together

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -954,7 +954,7 @@ def test_slice_edit_events():
     assert sl.value == slice(start, stop, step)
 
 
-def test_pushbutton_cick_signal():
+def test_pushbutton_click_signal():
     btn = widgets.PushButton(text="click me")
     mock = MagicMock()
     mock2 = MagicMock()


### PR DESCRIPTION
Typos found via `codespell -S .mypy_cache`

Note that I've encountered this while running `pre-commit`:

```bash
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

src/magicgui/widgets/_docs_sigs.py:28: error: Item "None" of "Optional[Any]"
has no attribute "__origin__"  [union-attr]
                        if valtype.__bound__.__origin__ is Union:
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/magicgui/widgets/_docs_sigs.py:30: error: Item "None" of "Optional[Any]"
has no attribute "__args__"  [union-attr]
    ...                       [str(c.__name__) for c in valtype.__bound__.__a...
                                                        ^~~~~~~~~~~~~~~~~~~~~...
Found 2 errors in 1 file (checked 42 source files)
```