### PR TITLE
Support nested `Annotated` types

### DIFF
--- a/src/magicgui/signature.py
+++ b/src/magicgui/signature.py
@@ -54,8 +54,10 @@ def make_annotated(annotation: Any = Any, options: dict | None = None) -> Any:
     _options = (options or {}).copy()
 
     if get_origin(annotation) is Annotated:
-        annotation, anno_options = get_args(annotation)
-        _options.update(anno_options)
+        # nested Annotated type results in multiple dicts.
+        annotation, *anno_options = get_args(annotation)
+        for opt in anno_options:
+            _options.update(opt)
     return Annotated[annotation, _options]
 
 

--- a/src/magicgui/signature.py
+++ b/src/magicgui/signature.py
@@ -57,6 +57,8 @@ def make_annotated(annotation: Any = Any, options: dict | None = None) -> Any:
         # nested Annotated type results in multiple dicts.
         annotation, *anno_options = get_args(annotation)
         for opt in anno_options:
+            if not isinstance(opt, dict):
+                raise TypeError("Every Annotated option must be a dict")
             _options.update(opt)
     return Annotated[annotation, _options]
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -52,7 +52,10 @@ def test_pick_widget_builtins_forward_refs(cls, string):
             Annotated[float, {"widget_type": "FloatSlider", "step": 9}],
             widgets.FloatSlider,
         ),
-        (Annotated[Annotated[int, {"widget_type": "Slider"}], {"max": 10}], widgets.Slider),
+        (
+            Annotated[Annotated[int, {"widget_type": "Slider"}], {"max": 10}],
+            widgets.Slider,
+        ),
     ],
 )
 def test_annotated_types(hint, expected_wdg):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -52,6 +52,7 @@ def test_pick_widget_builtins_forward_refs(cls, string):
             Annotated[float, {"widget_type": "FloatSlider", "step": 9}],
             widgets.FloatSlider,
         ),
+        (Annotated[Annotated[int, {"widget_type": "Slider"}], {"max": 10}], widgets.Slider),
     ],
 )
 def test_annotated_types(hint, expected_wdg):


### PR DESCRIPTION
Fixes #535 .

`get_args` returns multiple options if `Annotated` is nested. We can also easily support annotated-types in the future because it also uses multiple options like `Annotated[int, Gt(3), Lt(10)]` (raises a TypeError for now).