### PR TITLE
Fix recursion error when connecting to container self.method during subclass init 

### DIFF
--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -263,7 +263,9 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
     def __signature__(self) -> MagicSignature:
         """Return a MagicSignature object representing the current state of the gui."""
         params = [
-            MagicParameter.from_widget(w) for w in self._list if w.name and not w.gui_only
+            MagicParameter.from_widget(w)
+            for w in self._list
+            if w.name and not w.gui_only
         ]
         # if we have multiple non-default parameters and some but not all of them are
         # "bound" to fallback values, we may have  non-default arguments
@@ -316,7 +318,9 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
     def asdict(self) -> dict[str, Any]:
         """Return state of widget as dict."""
         return {
-            w.name: getattr(w, "value", None) for w in self._list if w.name and not w.gui_only
+            w.name: getattr(w, "value", None)
+            for w in self._list
+            if w.name and not w.gui_only
         }
 
     def update(

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,205 @@
+import pytest
+
+from magicgui import magicgui, use_app, widgets
+
+
+@pytest.mark.parametrize("scrollable", [False, True])
+def test_container_widget(scrollable):
+    """Test basic container functionality."""
+    container = widgets.Container(labels=False, scrollable=scrollable)
+    labela = widgets.Label(value="hi", name="labela")
+    labelb = widgets.Label(value="hi", name="labelb")
+    container.append(labela)
+    container.extend([labelb])
+    # different ways to index
+    assert container[0] == labela
+    assert container["labelb"] == labelb
+    assert container[:1] == [labela]
+    assert container[-1] == labelb
+
+    with pytest.raises(NotImplementedError):
+        container[0] = "something"
+
+    assert container.layout == "vertical"
+    with pytest.raises(NotImplementedError):
+        container.layout = "horizontal"
+
+    assert all(x in dir(container) for x in ["labela", "labelb"])
+
+    assert container.margins
+    container.margins = (8, 8, 8, 8)
+    assert container.margins == (8, 8, 8, 8)
+
+    del container[1:]
+    del container[-1]
+    assert not container
+    container.close()
+
+
+@pytest.mark.parametrize("scrollable", [False, True])
+def test_container_label_widths(scrollable):
+    """Test basic container functionality."""
+    container = widgets.Container(layout="vertical", scrollable=scrollable)
+    labela = widgets.Label(value="hi", name="labela")
+    labelb = widgets.Label(value="hi", name="I have a very long label")
+
+    def _label_width():
+        measure = use_app().get_obj("get_text_width")
+        return max(
+            measure(w.label)
+            for w in container
+            if not isinstance(w, widgets.bases.ButtonWidget)
+        )
+
+    container.append(labela)
+    before = _label_width()
+    container.append(labelb)
+    assert _label_width() > before
+    container.close()
+
+
+@pytest.mark.parametrize("scrollable", [False, True])
+def test_labeled_widget_container(scrollable):
+    """Test that _LabeledWidgets follow their children."""
+    from magicgui.widgets._concrete import _LabeledWidget
+
+    w1 = widgets.Label(value="hi", name="w1")
+    w2 = widgets.Label(value="hi", name="w2")
+    container = widgets.Container(
+        widgets=[w1, w2], layout="vertical", scrollable=scrollable
+    )
+    assert w1._labeled_widget
+    lw = w1._labeled_widget()
+    assert isinstance(lw, _LabeledWidget)
+    assert not lw.visible
+    container.show()
+    assert w1.visible
+    assert lw.visible
+    w1.hide()
+    assert not w1.visible
+    assert not lw.visible
+    w1.label = "another label"
+    assert lw._label_widget.value == "another label"
+    container.close()
+
+
+@pytest.mark.parametrize("scrollable", [False, True])
+def test_visible_in_container(scrollable):
+    """Test that visibility depends on containers."""
+    w1 = widgets.Label(value="hi", name="w1")
+    w2 = widgets.Label(value="hi", name="w2")
+    w3 = widgets.Label(value="hi", name="w3", visible=False)
+    container = widgets.Container(widgets=[w2, w3], scrollable=scrollable)
+    assert not w1.visible
+    assert not w2.visible
+    assert not w3.visible
+    assert not container.visible
+    container.show()
+    assert container.visible
+    assert w2.visible
+    assert not w3.visible
+    w1.show()
+    assert w1.visible
+    container.close()
+
+
+def test_delete_widget():
+    """We can delete widgets from containers."""
+    a = widgets.Label(name="a")
+    container = widgets.Container(widgets=[a])
+    # we can delete widgets
+    del container.a
+    with pytest.raises(AttributeError):
+        container.a
+
+    # they disappear from the layout
+    with pytest.raises(ValueError):
+        container.index(a)
+
+
+def test_reset_choice_recursion():
+    """Test that reset_choices recursion works for multiple types of widgets."""
+    x = 0
+
+    def get_choices(widget):
+        nonlocal x
+        x += 1
+        return list(range(x))
+
+    @magicgui(c={"choices": get_choices})
+    def f(c):
+        pass
+
+    assert f.c.choices == (0,)
+
+    container = widgets.Container(widgets=[f])
+    container.reset_choices()
+    assert f.c.choices == (0, 1)
+    container.reset_choices()
+    assert f.c.choices == (0, 1, 2)
+
+
+def test_container_indexing_with_native_mucking():
+    """Mostly make sure that the inner model isn't messed up.
+
+    keeping indexes with a manipulated native model *may* be something to do in future.
+    """
+    l1 = widgets.Label(name="l1")
+    l2 = widgets.Label(name="l2")
+    l3 = widgets.Label(name="l3")
+    c = widgets.Container(widgets=[l1, l2, l3])
+    assert c[-1] == l3
+    # so far they should be in sync
+    native = c.native.layout()
+    assert native.count() == len(c)
+    # much with native layout
+    native.addStretch()
+    # haven't changed the magicgui container
+    assert len(c) == 3
+    assert c[-1] == l3
+    # though it has changed the native model
+    assert native.count() == 4
+
+
+def test_containers_show_nested_containers():
+    """make sure showing a container shows a nested FunctionGui."""
+
+    @magicgui
+    def func(x: int, y: str):
+        pass
+
+    assert not func.visible
+    c2 = widgets.Container(widgets=[func])
+    assert not c2.visible
+    c2.show()
+    assert c2.visible and func.visible
+    c2.close()
+    assert not func.visible
+
+
+def test_container_removal():
+    c = widgets.Container()
+    s = widgets.Slider(label="label")
+    assert len(c) == 0
+    assert c.native.layout().count() == 0
+
+    c.append(s)
+    assert len(c) == 1
+    assert c.native.layout().count() == 1
+
+    c.pop()
+    assert len(c) == 0
+    assert c.native.layout().count() == 0
+
+
+def test_connection_during_init() -> None:
+    class C(widgets.Container):
+        def __init__(self) -> None:
+            btn = widgets.PushButton()
+            btn.changed.connect(self._on_clicked)
+            super().__init__(widgets=[btn])
+
+        def _on_clicked(self):
+            ...
+
+    assert isinstance(C(), widgets.Container)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -354,9 +354,6 @@ def test_bound_not_called():
     mock.assert_called_once_with(f.a)
 
 
-
-
-
 def test_progressbar():
     """Test manually controlling a progressbar."""
 
@@ -374,7 +371,6 @@ def test_progressbar():
         return pbar.get_value()
 
     assert t() == 23
-
 
 
 def test_main_function_gui():
@@ -500,8 +496,6 @@ def test_exception_range_out_of_range():
 
     with pytest.raises(ValueError):
         widgets.SpinBox(value=-10, min=0)
-
-
 
 
 def test_file_dialog_events():
@@ -721,8 +715,6 @@ def test_radiobutton_reset_choices():
     assert len(wdg.native.findChildren(QRadioButton)) == 3
     wdg.reset_choices()
     assert len(wdg.native.findChildren(QRadioButton)) == 3
-
-
 
 
 def test_tracking():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -252,120 +252,6 @@ def test_tooltip():
     assert label.tooltip == "My Tooltip"
 
 
-@pytest.mark.parametrize("scrollable", [False, True])
-def test_container_widget(scrollable):
-    """Test basic container functionality."""
-    container = widgets.Container(labels=False, scrollable=scrollable)
-    labela = widgets.Label(value="hi", name="labela")
-    labelb = widgets.Label(value="hi", name="labelb")
-    container.append(labela)
-    container.extend([labelb])
-    # different ways to index
-    assert container[0] == labela
-    assert container["labelb"] == labelb
-    assert container[:1] == [labela]
-    assert container[-1] == labelb
-
-    with pytest.raises(NotImplementedError):
-        container[0] = "something"
-
-    assert container.layout == "vertical"
-    with pytest.raises(NotImplementedError):
-        container.layout = "horizontal"
-
-    assert all(x in dir(container) for x in ["labela", "labelb"])
-
-    assert container.margins
-    container.margins = (8, 8, 8, 8)
-    assert container.margins == (8, 8, 8, 8)
-
-    del container[1:]
-    del container[-1]
-    assert not container
-    container.close()
-
-
-@pytest.mark.parametrize("scrollable", [False, True])
-def test_container_label_widths(scrollable):
-    """Test basic container functionality."""
-    container = widgets.Container(layout="vertical", scrollable=scrollable)
-    labela = widgets.Label(value="hi", name="labela")
-    labelb = widgets.Label(value="hi", name="I have a very long label")
-
-    def _label_width():
-        measure = use_app().get_obj("get_text_width")
-        return max(
-            measure(w.label)
-            for w in container
-            if not isinstance(w, widgets.bases.ButtonWidget)
-        )
-
-    container.append(labela)
-    before = _label_width()
-    container.append(labelb)
-    assert _label_width() > before
-    container.close()
-
-
-@pytest.mark.parametrize("scrollable", [False, True])
-def test_labeled_widget_container(scrollable):
-    """Test that _LabeledWidgets follow their children."""
-    from magicgui.widgets._concrete import _LabeledWidget
-
-    w1 = widgets.Label(value="hi", name="w1")
-    w2 = widgets.Label(value="hi", name="w2")
-    container = widgets.Container(
-        widgets=[w1, w2], layout="vertical", scrollable=scrollable
-    )
-    assert w1._labeled_widget
-    lw = w1._labeled_widget()
-    assert isinstance(lw, _LabeledWidget)
-    assert not lw.visible
-    container.show()
-    assert w1.visible
-    assert lw.visible
-    w1.hide()
-    assert not w1.visible
-    assert not lw.visible
-    w1.label = "another label"
-    assert lw._label_widget.value == "another label"
-    container.close()
-
-
-@pytest.mark.parametrize("scrollable", [False, True])
-def test_visible_in_container(scrollable):
-    """Test that visibility depends on containers."""
-    w1 = widgets.Label(value="hi", name="w1")
-    w2 = widgets.Label(value="hi", name="w2")
-    w3 = widgets.Label(value="hi", name="w3", visible=False)
-    container = widgets.Container(widgets=[w2, w3], scrollable=scrollable)
-    assert not w1.visible
-    assert not w2.visible
-    assert not w3.visible
-    assert not container.visible
-    container.show()
-    assert container.visible
-    assert w2.visible
-    assert not w3.visible
-    w1.show()
-    assert w1.visible
-    container.close()
-
-
-def test_delete_widget():
-    """We can delete widgets from containers."""
-    a = widgets.Label(name="a")
-    container = widgets.Container(widgets=[a])
-    # we can delete widgets
-    del container.a
-    with pytest.raises(AttributeError):
-        container.a
-
-    # they disappear from the layout
-    with pytest.raises(ValueError):
-        container.index(a)
-
-
 def test_widget_resolves_forward_ref():
     """The annotation on a widget should always be a resolved type."""
 
@@ -468,26 +354,7 @@ def test_bound_not_called():
     mock.assert_called_once_with(f.a)
 
 
-def test_reset_choice_recursion():
-    """Test that reset_choices recursion works for multiple types of widgets."""
-    x = 0
 
-    def get_choices(widget):
-        nonlocal x
-        x += 1
-        return list(range(x))
-
-    @magicgui(c={"choices": get_choices})
-    def f(c):
-        pass
-
-    assert f.c.choices == (0,)
-
-    container = widgets.Container(widgets=[f])
-    container.reset_choices()
-    assert f.c.choices == (0, 1)
-    container.reset_choices()
-    assert f.c.choices == (0, 1, 2)
 
 
 def test_progressbar():
@@ -508,27 +375,6 @@ def test_progressbar():
 
     assert t() == 23
 
-
-def test_container_indexing_with_native_mucking():
-    """Mostly make sure that the inner model isn't messed up.
-
-    keeping indexes with a manipulated native model *may* be something to do in future.
-    """
-    l1 = widgets.Label(name="l1")
-    l2 = widgets.Label(name="l2")
-    l3 = widgets.Label(name="l3")
-    c = widgets.Container(widgets=[l1, l2, l3])
-    assert c[-1] == l3
-    # so far they should be in sync
-    native = c.native.layout()
-    assert native.count() == len(c)
-    # much with native layout
-    native.addStretch()
-    # haven't changed the magicgui container
-    assert len(c) == 3
-    assert c[-1] == l3
-    # though it has changed the native model
-    assert native.count() == 4
 
 
 def test_main_function_gui():
@@ -656,20 +502,6 @@ def test_exception_range_out_of_range():
         widgets.SpinBox(value=-10, min=0)
 
 
-def test_containers_show_nested_containers():
-    """make sure showing a container shows a nested FunctionGui."""
-
-    @magicgui
-    def func(x: int, y: str):
-        pass
-
-    assert not func.visible
-    c2 = widgets.Container(widgets=[func])
-    assert not c2.visible
-    c2.show()
-    assert c2.visible and func.visible
-    c2.close()
-    assert not func.visible
 
 
 def test_file_dialog_events():
@@ -891,19 +723,6 @@ def test_radiobutton_reset_choices():
     assert len(wdg.native.findChildren(QRadioButton)) == 3
 
 
-def test_container_removal():
-    c = widgets.Container()
-    s = widgets.Slider(label="label")
-    assert len(c) == 0
-    assert c.native.layout().count() == 0
-
-    c.append(s)
-    assert len(c) == 1
-    assert c.native.layout().count() == 1
-
-    c.pop()
-    assert len(c) == 0
-    assert c.native.layout().count() == 0
 
 
 def test_tracking():


### PR DESCRIPTION
fixes #538  (the issue is that `self._list` wasn't yet assigned when calling `Container.__getattr__` from the super-init during construction... rest of changes are just moving container tests to a new file).

This was definitely a magicgui bug and not a psygnal bug, since you essentially couldn't call `getattr` on the container during subclass initialization

thanks for reporting @hanjinliu!  will get a new release out shortly