### PR TITLE
fix: accept any Annotated options that are castable to a dict

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:
@@ -12,6 +15,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.x'
       - run: pip install -e .[docs]
-      - run: mkdocs gh-deploy --strict --force
+
+      - name: Deploy docs to GitHub Pages
+        if: github.event_name == 'push'
+        run: mkdocs gh-deploy --strict --force
+      
+      - name: Test that docs build without error
+        if: github.event_name == 'pull_request'
+        run: mkdocs build --strict

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Deploy docs to GitHub Pages
         if: github.event_name == 'push'
         run: mkdocs gh-deploy --strict --force
-      
+
       - name: Test that docs build without error
         if: github.event_name == 'pull_request'
         run: mkdocs build --strict

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,4 +1,4 @@
-name: deploy docs
+name: docs
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  deploy:
+  docs:
     runs-on: macos-latest  # for the screenshots
     steps:
       - uses: actions/checkout@v3

--- a/src/magicgui/signature.py
+++ b/src/magicgui/signature.py
@@ -57,9 +57,13 @@ def make_annotated(annotation: Any = Any, options: dict | None = None) -> Any:
         # nested Annotated type results in multiple dicts.
         annotation, *anno_options = get_args(annotation)
         for opt in anno_options:
-            if not isinstance(opt, dict):
-                raise TypeError("Every Annotated option must be a dict")
-            _options.update(opt)
+            try:
+                _opt = dict(opt)
+            except TypeError as e:
+                raise TypeError(
+                    f"Every item in Annotated must be castable to a dict, got: {opt!r}"
+                ) from e
+            _options.update(_opt)
     return Annotated[annotation, _options]
 
 

--- a/src/magicgui/signature.py
+++ b/src/magicgui/signature.py
@@ -59,7 +59,7 @@ def make_annotated(annotation: Any = Any, options: dict | None = None) -> Any:
         for opt in anno_options:
             try:
                 _opt = dict(opt)
-            except TypeError as e:
+            except (TypeError, ValueError) as e:
                 raise TypeError(
                     f"Every item in Annotated must be castable to a dict, got: {opt!r}"
                 ) from e

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -8,9 +8,9 @@ def test_make_annotated_raises():
     """Test options to annotated must be a dict."""
     with pytest.raises(TypeError):
         make_annotated(int, "not a dict")  # type: ignore
-    
+
     with pytest.raises(TypeError):
-        make_annotated(Annotated[int, {'a': 1}, 'string'], 1)
+        make_annotated(Annotated[int, {"a": 1}, "string"], 1)
 
 
 def test_make_annotated_works_with_already_annotated():

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -8,6 +8,9 @@ def test_make_annotated_raises():
     """Test options to annotated must be a dict."""
     with pytest.raises(TypeError):
         make_annotated(int, "not a dict")  # type: ignore
+    
+    with pytest.raises(TypeError):
+        make_annotated(Annotated[int, {'a': 1}, 'string'], 1)
 
 
 def test_make_annotated_works_with_already_annotated():

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -12,7 +12,8 @@ def test_make_annotated_raises():
     with pytest.raises(TypeError):
         make_annotated(Annotated[int, "string"])
 
-    make_annotated(Annotated[int, (('a', 1),)])  # this is ok
+    make_annotated(Annotated[int, (("a", 1),)])  # this is ok
+
 
 def test_make_annotated_works_with_already_annotated():
     """Test that make_annotated merges options with Annotated types."""

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -10,8 +10,9 @@ def test_make_annotated_raises():
         make_annotated(int, "not a dict")  # type: ignore
 
     with pytest.raises(TypeError):
-        make_annotated(Annotated[int, {"a": 1}, "string"], 1)
+        make_annotated(Annotated[int, "string"])
 
+    make_annotated(Annotated[int, (('a', 1),)])  # this is ok
 
 def test_make_annotated_works_with_already_annotated():
     """Test that make_annotated merges options with Annotated types."""


### PR DESCRIPTION
This fixes the failing docs build from #536 ... which checks that all `Annotated` metadata are literal `dict` types, rather than just castable to a dict (which is also valid)