### PR TITLE
Register all types in a return_callback Union

### DIFF
--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -4,6 +4,8 @@
 
 import inspect
 from enum import Enum
+from typing import NewType, Optional
+from unittest.mock import Mock
 
 import pytest
 from qtpy.QtCore import Qt
@@ -878,3 +880,24 @@ def test_unknown_exception_create_widget():
     assert isinstance(
         widgets.create_widget(A, raise_on_unknown=False), widgets.EmptyWidget
     )
+
+
+@pytest.mark.parametrize("optional", [True, False])
+def test_call_union_return_type(optional: bool):
+    """registering Optional[type] should imply registering"""
+    mock = Mock()
+
+    NewInt = NewType("NewInt", int)
+    register_type(Optional[NewInt], return_callback=mock)
+
+    ReturnType = Optional[NewInt] if optional else NewInt
+
+    @magicgui
+    def func_optional(a: bool) -> ReturnType:
+        return NewInt(1) if a else None
+
+    func_optional(a=True)
+    mock.assert_called_once_with(func_optional, 1, ReturnType)
+    mock.reset_mock()
+    func_optional(a=False)
+    mock.assert_called_once_with(func_optional, None, ReturnType)


### PR DESCRIPTION
part of a fix to #541, this makes it so that when you use `register_type(Union[...], return_callback=...)`, then you effectively register the callback for functions that return either the union or any type within the Union (not just the actual union object itself)