### PR TITLE
Change exception to not confuse static code checkers

### DIFF
--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -184,7 +184,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
 
     def __setitem__(self, key: Any, value: Any) -> NoReturn:
         """Prevent assignment by index."""
-        raise NotImplementedError("magicgui.Container does not support item setting.")
+        raise RuntimeError("magicgui.Container does not support item setting.")
 
     def __dir__(self) -> list[str]:
         """Add subwidget names to the dir() call for this widget."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -17,7 +17,7 @@ def test_container_widget(scrollable):
     assert container[:1] == [labela]
     assert container[-1] == labelb
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError):
         container[0] = "something"
 
     assert container.layout == "vertical"


### PR DESCRIPTION
When using `NotImplementedError`, the static code checkers like pylint marks a method as required to implement in a subclass. I suggest changing to `RuntimeError`  (but I'm not glued to this selection of exception class). 

![obraz](https://user-images.githubusercontent.com/3826210/229576535-92709069-aec2-4082-8606-b07dc77ec9bb.png)
