### PR TITLE
fix: fix binding of non ValueWidgets in guiclass

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -101,7 +101,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[testing,pyqt5]
-          pip install numpy superqt vispy pyqtgraph
           python -m pip install ./magic-class[testing]
 
       - name: Test magicclass

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -102,7 +102,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[testing,pyqt5]
           pip install numpy superqt vispy pyqtgraph
-          python -m pip install ./magic-class
+          python -m pip install ./magic-class[testing]
 
       - name: Test magicclass
         uses: aganders3/headless-gui@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ testing = [
     "pint>=0.13.0",
     "matplotlib",
     "toolz",
-    "ipywidgets",
+    "ipywidgets; python_version>='3.9'",
     "ipykernel",
     "pydantic",
     "attrs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ testing = [
     "pint>=0.13.0",
     "matplotlib",
     "toolz",
-    "ipywidgets; python_version>='3.9'",
+    "ipywidgets",
+    "ipython<8.13; python_version<='3.9'",
     "ipykernel",
     "pydantic",
     "attrs",
@@ -121,7 +122,7 @@ docs = [
     "pint",
     "ipywidgets>=8.0.0",
     "ipykernel",
-    "pyside6==6.4.2",  # 6.4.3 gives segfault for some reason
+    "pyside6==6.4.2",    # 6.4.3 gives segfault for some reason
 ]
 
 [project.urls]

--- a/src/magicgui/schema/_guiclass.py
+++ b/src/magicgui/schema/_guiclass.py
@@ -13,7 +13,7 @@ import warnings
 from dataclasses import Field, dataclass, field, is_dataclass
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar, overload
 
-from psygnal import SignalGroup, evented
+from psygnal import SignalGroup, SignalInstance, evented
 from psygnal import __version__ as psygnal_version
 
 from magicgui.schema._ui_field import build_widget
@@ -264,27 +264,35 @@ def bind_gui_to_instance(
         warnings.simplefilter("ignore", category=RuntimeWarning)
 
         for widget in gui:
+            # would be cleaner to check isinstance(widget, ValueWidget)... but a few
+            # widgets (like FileEdit) are not ValueWidgets, but still have a `changed`
+            # signal and a value method. So for now we just check for the protocol.
+            changed = getattr(widget, "changed", None)
+
             # we skip PushButton here, otherwise we will set the value of the
             # button (a boolean) to some attribute on the instance, which is probably
             # not what we want.
-            if isinstance(widget, ValueWidget) and not isinstance(widget, PushButton):
+            if isinstance(changed, SignalInstance) and not isinstance(
+                widget, PushButton
+            ):
+                name: str = getattr(widget, "name", "")
                 # connect changes in the widget to the instance
-                if hasattr(instance, widget.name):
+                if hasattr(instance, name):
                     try:
-                        widget.changed.connect_setattr(
-                            instance, widget.name, **_IGNORE_REF_ERR  # type: ignore
+                        changed.connect_setattr(
+                            instance, name, **_IGNORE_REF_ERR  # type: ignore
                         )
                     except TypeError:
                         warnings.warn(
-                            f"Could not bind {widget.name} to {instance}. "
+                            f"Could not bind {name} to {instance}. "
                             "This may be because the instance has __slots__ or "
                             "other attribute restrictions. Please update psygnal.",
                             stacklevel=2,
                         )
 
                 # connect changes from the instance to the widget
-                if widget.name in signals:
-                    signals[widget.name].connect_setattr(widget, "value")
+                if name in signals:
+                    signals[name].connect_setattr(widget, "value")
 
 
 def unbind_gui_from_instance(gui: ContainerWidget, instance: Any) -> None:

--- a/tests/test_gui_class.py
+++ b/tests/test_gui_class.py
@@ -161,7 +161,9 @@ def test_path_update():
         a: Path = Path("blabla")
 
     obj = MyGuiClass()
-    assert obj.gui.a.value.resolve() == Path("blabla").resolve()
-    assert obj.a.resolve() == Path("blabla").resolve()
+    assert obj.gui.a.value.stem == "blabla"
+    assert obj.a.stem == "blabla"
+
     obj.gui.a.value = "foo"
-    assert obj.a.resolve() == Path("foo").resolve()
+    assert obj.gui.a.value.stem == "foo"
+    assert obj.a.stem == "foo"

--- a/tests/test_gui_class.py
+++ b/tests/test_gui_class.py
@@ -161,7 +161,7 @@ def test_path_update():
         a: Path = Path("blabla")
 
     obj = MyGuiClass()
-
-    assert obj.a.resolve() == Path("blabla").resolve() == obj.gui.a.value
+    assert obj.gui.a.value.resolve() == Path("blabla").resolve()
+    assert obj.a.resolve() == Path("blabla").resolve()
     obj.gui.a.value = "foo"
     assert obj.a.resolve() == Path("foo").resolve()

--- a/tests/test_gui_class.py
+++ b/tests/test_gui_class.py
@@ -146,3 +146,22 @@ def test_guiclass_as_class():
     assert t2.gui.y.value == "baz"
     assert isinstance(t2.gui.foo, PushButton)
     assert t2.foo() == {"x": 3, "y": "baz"}
+
+
+def test_path_update():
+    """One off test for FileEdits... which weren't updating.
+
+    (The deeper issue is that things like FileEdit don't subclass ValueWidget...)
+    """
+
+    from pathlib import Path
+
+    @guiclass
+    class MyGuiClass:
+        a: Path = Path("blabla")
+
+    obj = MyGuiClass()
+
+    assert obj.a.resolve() == Path("blabla").resolve() == obj.gui.a.value
+    obj.gui.a.value = "foo"
+    assert obj.a.resolve() == Path("foo").resolve()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -12,10 +12,18 @@ from magicgui.widgets import Container, request_values
 from magicgui.widgets.bases import DialogWidget, ValueWidget
 from tests import MyInt
 
+BACKENDS = ["qt"]
+try:
+    import ipywidgets  # noqa
+
+    BACKENDS.append("ipynb")
+except ImportError:
+    pass
+
 
 # it's important that "qt" be last here, so that it's used for
 # the rest of the tests
-@pytest.fixture(scope="module", params=["ipynb", "qt"])
+@pytest.fixture(scope="module", params=BACKENDS)
 def backend(request):
     return request.param
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -12,18 +12,10 @@ from magicgui.widgets import Container, request_values
 from magicgui.widgets.bases import DialogWidget, ValueWidget
 from tests import MyInt
 
-BACKENDS = ["qt"]
-try:
-    import ipywidgets  # noqa
-
-    BACKENDS.append("ipynb")
-except ImportError:
-    pass
-
 
 # it's important that "qt" be last here, so that it's used for
 # the rest of the tests
-@pytest.fixture(scope="module", params=BACKENDS)
+@pytest.fixture(scope="module", params=["ipynb", "qt"])
 def backend(request):
     return request.param
 


### PR DESCRIPTION
fixes #555 

the deeper issue is that FileEdit implements a very similar protocol to ValueWidget (has a `changed` event and `value`), but doesn't subclass it... so changes to the widget weren't getting bound to the model.