### PR TITLE
Update `choices` setter for categorical widget to ensure `_default_choices` are updated when a `callable` choices is passed

### DIFF
--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -137,7 +137,8 @@ class CategoricalWidget(ValueWidget[T]):
             str_func = choices["key"]
         elif not isinstance(choices, EnumMeta) and callable(choices):
             _choices = choices(self)
-
+            # The following line ensures that when setting choices with a callable, the default choices are also updated with that callable
+            self._default_choices = choices
         else:
             _choices = choices
 

--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -137,7 +137,8 @@ class CategoricalWidget(ValueWidget[T]):
             str_func = choices["key"]
         elif not isinstance(choices, EnumMeta) and callable(choices):
             _choices = choices(self)
-            # The following line ensures that when setting choices with a callable, the default choices are also updated with that callable
+            # ensure that when setting choices with a callable,
+            # the default choices are also updated with that callable
             self._default_choices = choices
         else:
             _choices = choices

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -721,6 +721,23 @@ def test_categorical_change_choices(Cls):
     assert wdg.choices == c
 
 
+@pytest.mark.parametrize("Cls", [widgets.ComboBox, widgets.RadioButtons])
+def test_categorical_change_choices_callable(Cls):
+    first_choices = ["c", "d"]
+
+    def get_choices(wdg):
+        return ["a", "b"]
+
+    wdg = Cls(choices=first_choices)
+    assert wdg.choices == first_choices
+    assert wdg._default_choices == first_choices
+
+    wdg.choices = get_choices
+
+    assert wdg.choices == get_choices
+    assert wdg._default_choices == get_choices
+
+
 @pytest.mark.skipif(use_app().backend_name != "qt", reason="only on qt")
 def test_radiobutton_reset_choices():
     """Test that reset_choices doesn't change the number of buttons."""

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -734,7 +734,7 @@ def test_categorical_change_choices_callable(Cls):
 
     wdg.choices = get_choices
 
-    assert wdg.choices == get_choices
+    assert wdg.choices == ("c", "d")
     assert wdg._default_choices == get_choices
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -723,10 +723,10 @@ def test_categorical_change_choices(Cls):
 
 @pytest.mark.parametrize("Cls", [widgets.ComboBox, widgets.RadioButtons])
 def test_categorical_change_choices_callable(Cls):
-    first_choices = ["c", "d"]
+    first_choices = ["a", "b"]
 
     def get_choices(wdg):
-        return ["a", "b"]
+        return ["c", "d"]
 
     wdg = Cls(choices=first_choices)
     assert wdg.choices == first_choices

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -723,10 +723,10 @@ def test_categorical_change_choices(Cls):
 
 @pytest.mark.parametrize("Cls", [widgets.ComboBox, widgets.RadioButtons])
 def test_categorical_change_choices_callable(Cls):
-    first_choices = ["a", "b"]
+    first_choices = ("a", "b")
 
     def get_choices(wdg):
-        return ["c", "d"]
+        return ("c", "d")
 
     wdg = Cls(choices=first_choices)
     assert wdg.choices == first_choices


### PR DESCRIPTION
Noticed that the `choices` setter for categorical widgets doesn't update `_default_choices`, even though `_default_choices` is set when a `callable` is passed on `init`. In our plugin we have to set `choices` to a callable after widget creation, but we've noticed the combo box doesn't get populated correctly until we force some other event change. This PR fixes that and makes sure `reset_choices` uses the callable.

I've added a comment and a test that fails on main and passes with this PR.

Let me know if this makes sense or if there's a better way to achieve the desired behaviour! Thanks!

cc @jni 