### PR TITLE
Replace QSpinBox with QLargeIntSpinBox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ min-req = [
     "docstring_parser==0.7",
     "psygnal==0.5.0",
     "qtpy==1.7.0",
-    "superqt==0.4.0",
+    "superqt==0.5.0",
     "typing_extensions",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "docstring_parser>=0.7",
     "psygnal>=0.5.0",
     "qtpy>=1.7.0",
-    "superqt>=0.4.0",
+    "superqt>=0.5.0",
     "typing_extensions",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "docstring_parser>=0.7",
         "psygnal>=0.5.0",
         "qtpy>=1.7.0",
-        "superqt>=0.4.0",
+        "superqt>=0.5.0",
         "typing_extensions",
     ],
 )

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -348,7 +348,7 @@ class TextEdit(QBaseStringWidget, protocols.SupportsReadOnly):
 class QBaseRangedWidget(QBaseValueWidget, protocols.RangedWidgetProtocol):
     """Provides min/max/step implementations."""
 
-    _qwidget: QtW.QDoubleSpinBox | QtW.QSpinBox | QtW.QAbstractSlider
+    _qwidget: QtW.QDoubleSpinBox | superqt.QLargeIntSpinBox | QtW.QAbstractSlider
     _precision: float = 1
 
     def __init__(self, qwidg: type[QtW.QWidget], **kwargs: Any) -> None:
@@ -566,7 +566,8 @@ class MainWindow(Container):
 
 class SpinBox(QBaseRangedWidget):
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(QtW.QSpinBox, **kwargs)
+        # TODO: Consider any performance impace of this widget over a QSpinBox
+        super().__init__(superqt.QLargeIntSpinBox, **kwargs)
 
     def _mgui_set_value(self, value) -> None:
         super()._mgui_set_value(int(value))
@@ -637,7 +638,8 @@ class _Slider(QBaseRangedWidget, protocols.SupportsOrientation):
 
 class Slider(_Slider):
     _qwidget: QtW.QSlider
-    _readout = QtW.QSpinBox
+    # TODO: Consider any performance impace of this widget over a QSpinBox
+    _readout = superqt.QLargeIntSpinBox
 
     def __init__(self, qwidg=QtW.QSlider, **kwargs: Any) -> None:
         self._container = QtW.QWidget()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -769,7 +769,7 @@ def test_slider_readeout():
     sld = widgets.Slider()
     sld.show()
     backend_slider = sld.native.children()[1]
-    assert "QSpinBox" in type(backend_slider).__name__
+    assert "SpinBox" in type(backend_slider).__name__
     assert backend_slider.isVisible()
 
     sld = widgets.Slider(readout=False)


### PR DESCRIPTION
The range of QSpinBox is limited to a 32-bit signed integer - Python integers can go much larger than that. By using QLargeIntSpinBox instead, we enable larger range options!