### PR TITLE
Fix broken mkdocs links

### DIFF
--- a/docs/api/migration.md
+++ b/docs/api/migration.md
@@ -68,10 +68,10 @@ breaking API changes
 
 ### `.Gui()` attribute removed
 
-Before `v0.2.0`, the [`magicgui.magicgui`][] decorator added a `Gui` attribute to
+Before `v0.2.0`, the [`magicgui.magicgui`][magicgui.magicgui] decorator added a `Gui` attribute to
 the decorated function that was to be called to instantiate a widget.  In `v0.2.0`
-the object returned from the [`magicgui.magicgui`][] decorator is already an
-instantiated [`magicgui.widgets.Widget`][].
+the object returned from the [`magicgui.magicgui`][magicgui.magicgui] decorator is already an
+instantiated [`magicgui.widgets.Widget`][magicgui.widgets.Widget].
 
 ```python title="👎 Old Method (< v0.2.0)"
 from magicgui import magicgui, event_loop
@@ -97,11 +97,11 @@ function.show(run=True)
 
 ### New base widget type
 
-Before `v0.2.0`, the `Gui()` object returned by the [`magicgui.magicgui`][]
+Before `v0.2.0`, the `Gui()` object returned by the [`magicgui.magicgui`][magicgui.magicgui]
 decorator was a `MagicGuiBase` widget class, which in turn was a *direct
 subclass* of a backend widget, such as a
 [`QtWidgets.QWidget`](https://doc.qt.io/qt-5/qwidget.html).  In `v0.2.0`, all
-widgets derive from [magicgui.widgets.Widget][],
+widgets derive from [`magicgui.widgets.Widget``][magicgui.widgets.Widget],
 and the *backend* is available at `widget.native`.  If you are incorporating
 magicgui widgets into a larger Qt-based GUI, please note that you will want
 to use `widget.native` instead of `widget`

--- a/docs/dataclasses.md
+++ b/docs/dataclasses.md
@@ -64,14 +64,14 @@ library.
 
 **magicgui** supports the dataclass API as a way to define the interface for compound
 widget, where each attribute of the dataclass is a separate widget.  The
-[`magicgui.experimental.guiclass`][] decorator can be used to mark a class
+[`magicgui.experimental.guiclass`][magicgui.experimental.guiclass] decorator can be used to mark a class
 as a "GUI class".  A GUI class *is* a Python standard [`dataclass`][dataclasses.dataclass]
 that has two additional features:
 
 1. A property (named "`gui`" by default) that returns a [`Container`][magicgui.widgets.Container]
    widget which contains a widget for each attribute of the dataclass.
 2. An property (named "`events`" by default) that returns a
-   [`psygnal.SignalGroup`][] object that allows you to connect callbacks
+   [`psygnal.SignalGroup`][psygnal.SignalGroup] object that allows you to connect callbacks
    to the change event of any of field in the dataclass.  (Under the hood,
    this uses the
    [`@evented` dataclass decorator from `psygnal`](https://psygnal.readthedocs.io/en/latest/dataclasses/).)
@@ -128,7 +128,7 @@ obj.gui.show()
 Buttons are one of the few widget types that tend not to have an associated
 value, but simply trigger a callback when clicked.  That is: it doesn't often
 make sense to add a field to a dataclass representing a button. To add a button
-to a `guiclass`, decorate a method with the [`magicgui.experimental.button`][]
+to a `guiclass`, decorate a method with the [`magicgui.experimental.button`][magicgui.experimental.button]
 decorator.
 
 !!! warning "positioning buttons"
@@ -136,7 +136,7 @@ decorator.
     to position the button in the layout will be added in the future.
 
 Any additional keyword arguments to the `button` decorator will be passed to the
-[`magicgui.widgets.PushButton`][] constructor (e.g. `label`, `tooltip`, etc.)
+[`magicgui.widgets.PushButton`][magicgui.widgets.PushButton] constructor (e.g. `label`, `tooltip`, etc.)
 
 ``` python
 from magicgui.experimental import guiclass, button

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -2,7 +2,7 @@
 
 ## From Object to GUI
 
-The eponymous feature of `magicgui` is the [`magicgui.magicgui`][] function,
+The eponymous feature of `magicgui` is the [`magicgui.magicgui`][magicgui.magicgui] function,
 which converts an object into a widget.
 
 !!! info
@@ -43,13 +43,13 @@ def snells_law(aoi=30.0, n1=Medium.Glass, n2=Medium.Water, degrees=True):
 snells_law.show() # leave open
 ```
 
-The object returned by the `magicgui` decorator is an instance of [`magicgui.widgets.FunctionGui`][].  It can still be called like the original function, but it also knows how to present itself as a GUI.
+The object returned by the `magicgui` decorator is an instance of [`magicgui.widgets.FunctionGui`][magicgui.widgets.FunctionGui].  It can still be called like the original function, but it also knows how to present itself as a GUI.
 
 ## Two-Way Data Binding
 
 The modified `snells_law` object gains attributes named after each of the
 parameters in the function.  Each attribute is an instance of a
-[`magicgui.widgets.Widget`] subclass (suitable for the data type represented by
+[`magicgui.widgets.Widget`][magicgui.widgets.Widget] subclass (suitable for the data type represented by
 that parameter). As you make changes in your GUI, the attributes of the
 `snells_law` object will be kept in sync.  For instance, change the first
 dropdown menu from "Glass" to "Oil", and the corresponding `n1` object on
@@ -194,7 +194,7 @@ widget_instance = magicgui(function)
 
 ## magic_factory
 
-The [`magicgui.magic_factory`][] function/decorator acts very much like the `magicgui`
+The [`magicgui.magic_factory`][magicgui.magic_factory] function/decorator acts very much like the `magicgui`
 decorator, with one important difference:
 
 **Unlike `magicgui`, `magic_factory` does not return a widget instance
@@ -210,7 +210,7 @@ subclass).
 
 !!! tip "it's just a partial"
 
-    If you're familiar with [`functools.partial`][], you can think of
+    If you're familiar with [`functools.partial`][functools.partial], you can think of
     `magic_factory` as a partial function application of the `magicgui`
     decorator (in fact, `magic_factory` is a subclass of `partial`).
     It is very roughly equivalent to:
@@ -246,7 +246,7 @@ new_widget = my_factory()
 
 Just to demystify the name a bit, there really isn't a whole lot of "magic"
 in the `magicgui` decorator.  It's really just a thin wrapper around the
-[`magicgui.widgets.create_widget`][] function, to create a
+[`magicgui.widgets.create_widget`][magicgui.widgets.create_widget] function, to create a
 [`Container`][magicgui.widgets.Container] with a sub-widget for each
 parameter in the function signature.
 

--- a/docs/examples/napari/napari_img_math.py
+++ b/docs/examples/napari/napari_img_math.py
@@ -94,7 +94,7 @@ def image_arithmetic(array1, operation, array2):
 
 `magicgui` works particularly well with [type annotations](https://docs.python.org/3/library/typing.html),
 and allows third-party libraries to register widgets and behavior for handling
-their custom types (using [`magicgui.type_map.register_type`][]).
+their custom types (using [`magicgui.type_map.register_type`][magicgui.type_map.register_type]).
 `napari` [provides support for `magicgui`](https://github.com/napari/napari/blob/main/napari/utils/_magicgui.py)
 by registering a dropdown menu whenever a function parameter is annotated as one
 of the basic napari [`Layer` types](https://napari.org/howtos/layers/index.html),
@@ -137,7 +137,7 @@ into other GUIs (such as the napari GUI shown in this example)
 ### create dropdowns with Enums
 
 We'd like the user to be able to select the operation (`add`, `subtract`,
-`multiply`, `divide`) using a dropdown menu. [`enum.Enum`][] offers a convenient
+`multiply`, `divide`) using a dropdown menu. [`enum.Enum`][enum.Enum] offers a convenient
 way to restrict values to a strict set of options, while providing `name: value`
 pairs for each of the options. Here, the value for each choice is the actual
 function we would like to have called when that option is selected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ dataclasses simply by annotating them with standard python
 
 #### `create_widget`
 
-[`magicgui.widgets.create_widget`][] is a general function, used throughout the library, that allows you to create a widget for a specific Python type or value:
+[`magicgui.widgets.create_widget`][magicgui.widgets.create_widget] is a general function, used throughout the library, that allows you to create a widget for a specific Python type or value:
 
 ```python
 from magicgui.widgets import create_widget
@@ -92,7 +92,7 @@ For more details on how magicgui maps types to widgets, see
 
 #### magicgui
 
-The [`magicgui.magicgui`][] function is one way to
+The [`magicgui.magicgui`][magicgui.magicgui] function is one way to
 autogenerate a compound Widget based on the parameters of a function:
 
 ```python
@@ -124,8 +124,8 @@ decorators](decorators.md) page.
 
 #### :material-flask-outline: guiclass
 
-[`magicgui.experimental.guiclass`][] is a newer experimental feature that provides an object-oriented
-alternative to `magicgui`.  It wraps [`dataclasses.dataclass`][] and adds a
+[`magicgui.experimental.guiclass`][magicgui.experimental.guiclass] is a newer experimental feature that provides an object-oriented
+alternative to `magicgui`.  It wraps [`dataclasses.dataclass`][dataclasses.dataclass] and adds a
 `gui` attribute to the resulting class, which is a `magicgui`-generated widget
 that can be used to control the dataclass instance.  (The widget is only created
 when the `gui` attribute is accessed for the first time.)

--- a/docs/type_map.md
+++ b/docs/type_map.md
@@ -64,12 +64,12 @@ wdg.show()
 ## Customizing Widget Options with `typing.Annotated`
 
 Widget options and types may be embedded in the type hint itself using
-[`typing.Annotated`][].
+[`typing.Annotated`][typing.Annotated].
 
 
 !!! note
     This is not the *only* way to customize the widget type or options
-    in magicgui.  Some functions (like [`magicgui.magicgui`][]) also accept
+    in magicgui.  Some functions (like [`magicgui.magicgui`][magicgui.magicgui]) also accept
     `**param_options` keyword arguments that map parameter names to
     dictionaries of widget options.
 
@@ -127,7 +127,7 @@ Create a widget using standard type map:
     my_widget = obj.gui
     ```
 
-Customize a widget using [`typing.Annotated`][]:
+Customize a widget using [`typing.Annotated`][typing.Annotated]:
 
 === "create_widget"
 
@@ -270,7 +270,7 @@ As a general rule, if you *must* use forward references or
 
 ## Registering Support for Custom Types
 
-Any third-party library may use the [`magicgui.register_type`][] function to
+Any third-party library may use the [`magicgui.register_type`][magicgui.register_type] function to
 register its types with magicgui.  When a registered type is used as an
 annotation, the registered widget will be used.
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -5,7 +5,7 @@
     [Widget Index](api/widgets/index.md).
 
 All individual graphical elements in **magicgui** are "widgets", and all widgets
-are instances of [`magicgui.widgets.Widget`][].  Widgets may be created
+are instances of [`magicgui.widgets.Widget`][magicgui.widgets.Widget].  Widgets may be created
 directly:
 
 ```python
@@ -15,7 +15,7 @@ line_edit = LineEdit(value='hello!')
 line_edit.show()
 ```
 
-Some widgets (such as [`magicgui.widgets.Container`][]) are composite
+Some widgets (such as [`magicgui.widgets.Container`][magicgui.widgets.Container]) are composite
 widgets that comprise other widgets:
 
 ```python
@@ -28,7 +28,7 @@ container.show()
 ```
 
 **magicgui** provides a way to automatically select a widget given a python value
-or type annotation using [`magicgui.widgets.create_widget`][]. Here is an
+or type annotation using [`magicgui.widgets.create_widget`][magicgui.widgets.create_widget]. Here is an
 example that yields the same result as the one above:
 
 ```python
@@ -83,15 +83,15 @@ properties and attributes it has.
 
 ### `Widget`
 
-As mentioned above, all magicgui widgets derive from [`magicgui.widgets.Widget`][] and have the
+As mentioned above, all magicgui widgets derive from [`magicgui.widgets.Widget`][magicgui.widgets.Widget] and have the
 following attributes (this list is not comprehensive, see
-the [`magicgui.widgets.Widget`][] API):
+the [`magicgui.widgets.Widget`][magicgui.widgets.Widget] API):
 
 | <div style="width:80px">Attribute</div> | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | The name or "ID" of this widget (such as a function parameter name to which this widget corresponds). |
 | `annotation` | `Any` | A type annotation for the value represented by the widget. |
-| `label` | `str` | A string to use for an associated Label widget (if this widget is being shown in a [`magicgui.widgets.Container`][] widget, and `container.labels` is `True`). By default, `name` will be used. Note: `name` refers the name of the parameter, as might be used in a signature, whereas label is just the label for that widget in the GUI. |
+| `label` | `str` | A string to use for an associated Label widget (if this widget is being shown in a [`magicgui.widgets.Container`][magicgui.widgets.Container] widget, and `container.labels` is `True`). By default, `name` will be used. Note: `name` refers the name of the parameter, as might be used in a signature, whereas label is just the label for that widget in the GUI. |
 | `tooltip` | `str` | A tooltip to display when hovering over the widget. |
 | `visible` | `bool` | Whether the widget is visible. |
 
@@ -118,7 +118,7 @@ following `ValueWidgets` track some `value`:
 | <div style="width:80px">Attribute</div> | Type | Description |
 |-----------|------|-------------|
 | `value` | `Any` | The current value of the widget. |
-| `changed` | [`psygnal.SignalInstance`][] | A [`psygnal.SignalInstance`][] that will emit an event when the `value` has changed.  Connect callbacks to the change event using `widget.changed.connect(callback)` |
+| `changed` | [`psygnal.SignalInstance`][psygnal.SignalInstance] | A [`psygnal.SignalInstance`][psygnal.SignalInstance] that will emit an event when the `value` has changed.  Connect callbacks to the change event using `widget.changed.connect(callback)` |
 | `bind` | `Any, optional` | A value or callback to bind this widget.  If bound, whenever `widget.value` is accessed, the value provided here will be returned.  The bound value can be a callable, in which case `bound_value(self)` will be returned (i.e. your callback must accept a single parameter, which is this widget instance.). see [`ValueWidget.bind`][magicgui.widgets.bases.ValueWidget.bind] for details. |
 
 Here is a demonstration of all these:
@@ -225,10 +225,10 @@ container.show()
 `CategoricalWidget` are [`ValueWidgets`](#valuewidget) that provide a set
 of valid choices.  They can be created from:
 
-- an [`enum.Enum`][]
+- an [`enum.Enum`][enum.Enum]
 - an iterable of objects (or an iterable of 2-tuples `(name, object)`)
-- a callable that returns an [`enum.Enum`][] or an iterable
-- a [`typing.Literal`][] annotation.
+- a callable that returns an [`enum.Enum`][enum.Enum] or an iterable
+- a [`typing.Literal`][typing.Literal] annotation.
 
 ::: autosummary
     magicgui.widgets.ComboBox
@@ -257,8 +257,8 @@ container.show()
 
 A `ContainerWidget` is a list-like `Widget` that can contain other widgets.
 Containers allow you to build more complex widgets from sub-widgets. A notable
-example of a `Container` is [`magicgui.widgets.FunctionGui`][]) (the product of
-the [`@magicgui`][magicgui.magicgui] decorator).
+example of a `Container` is [`magicgui.widgets.FunctionGui`][magicgui.widgets.FunctionGui])
+(the product of the [`@magicgui`][magicgui.magicgui] decorator).
 
 ::: autosummary
     magicgui.widgets.Container
@@ -271,8 +271,8 @@ the [`@magicgui`][magicgui.magicgui] decorator).
 | `widgets` | `Sequence[Widget]` | The widgets that the container contains. |
 | `labels` | `bool` | Whether each widget should be shown with a corresponding `Label` widget to the left.  Note: the text for each widget defaults to `widget.name`, but can be overridden by setting `widget.label`. |
 
-`Container` implements the full [`collections.abc.MutableSequence`][] interface.  You
-can add and remove widgets from it just as you would add or remove items from a list.
+`Container` implements the full [`collections.abc.MutableSequence`][collections.abc.MutableSequence] interface.
+You can add and remove widgets from it just as you would add or remove items from a list.
 
 ```python
 from magicgui.widgets import Container, Slider, FloatSlider, ProgressBar
@@ -293,7 +293,8 @@ bar.
 A `FunctionGui` is a special type of [`ContainerWidget`](#containerwidget)
 that is created from a function.  It is the product of the
 [`@magicgui`][magicgui.magicgui] decorator.  It is a container that contains a
-widget for each of the parameters in the function.  See [`magicgui.widgets.FunctionGui`][] for details.
+widget for each of the parameters in the function.
+See [`magicgui.widgets.FunctionGui`][magicgui.widgets.FunctionGui] for details.
 
 #### `@magicgui`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,7 @@ plugins:
       gallery_dirs: [docs/generated_examples]
       filename_pattern: /*.py  # which scripts will be executed for the docs
       ignore_pattern: /__init__.py  # ignore these example files completely
-      run_stale_examples: True
+      run_stale_examples: False
   - spellcheck:
       backends: # the backends you want to use
         - codespell: # or nested configs

--- a/src/magicgui/tqdm.py
+++ b/src/magicgui/tqdm.py
@@ -44,7 +44,8 @@ class tqdm(_tqdm_std):
 
     See tqdm.tqdm API for valid args and kwargs: https://tqdm.github.io/docs/tqdm/
 
-    Also, any keyword arguments to the [magicgui.widgets.ProgressBar][] widget
+    Also, any keyword arguments to the
+    [``magicgui.widgets.ProgressBar``][magicgui.widgets.ProgressBar] widget
     are also accepted and will be passed to the ``ProgressBar``.
 
     Examples

--- a/src/magicgui/type_map/_magicgui.py
+++ b/src/magicgui/type_map/_magicgui.py
@@ -313,7 +313,8 @@ def magic_factory(
     1. Whereas `magicgui` returns a `FunctionGui` instance, `magic_factory` returns a
        callable that returns a `FunctionGui` instance.  (Technically, it returns an
        instance of [`MagicFactory`][magicgui.type_map._magicgui.MagicFactory] which you
-       behaves exactly like a [`functools.partial`][] for a `FunctionGui` instance.)
+       behaves exactly like a [`functools.partial`][functools.partial]
+       for a `FunctionGui` instance.)
     2. `magic_factory` adds a `widget_init` method: a callable that will be called
         immediately after the `FunctionGui` instance is created.  This can be used to
         add additional widgets to the layout, or to connect signals to the widgets.
@@ -418,7 +419,7 @@ class MagicFactory(partial, Generic[_R, _T]):
     """Factory function that returns a FunctionGui instance.
 
     While this can be used directly, (see example below) the preferred usage is
-    via the [`magicgui.magic_factory`][] decorator.
+    via the [`magicgui.magic_factory`][magicgui.magic_factory] decorator.
 
     Examples
     --------

--- a/src/magicgui/type_map/_type_map.py
+++ b/src/magicgui/type_map/_type_map.py
@@ -304,7 +304,7 @@ def get_widget_class(
     is_result: bool = False,
     raise_on_unknown: bool = True,
 ) -> tuple[WidgetClass, dict]:
-    """Return a [magicgui.widgets.Widget][] subclass for the given `value`/`annotation`.
+    """Return a [Widget][magicgui.widgets.Widget] subclass for the `value`/`annotation`.
 
     Parameters
     ----------

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -21,7 +21,7 @@ class ChoicesDict(TypedDict):
 
 
 #: A [`Widget`][magicgui.widgets.Widget] class or a
-#: [`WidgetProtocol``][magicgui.widgets.protocols.WidgetProtocol]
+#: [`WidgetProtocol`][magicgui.widgets.protocols.WidgetProtocol]
 WidgetClass = Union["type[Widget]", "type[WidgetProtocol]"]
 #: A generic reference to a :attr:`WidgetClass` as a string, or the class itself.
 WidgetRef = Union[str, WidgetClass]

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -21,7 +21,7 @@ class ChoicesDict(TypedDict):
 
 
 #: A [`Widget`][magicgui.widgets.Widget] class or a
-#: [~magicgui.widgets.protocols.WidgetProtocol][]
+#: [`WidgetProtocol``][magicgui.widgets.protocols.WidgetProtocol]
 WidgetClass = Union["type[Widget]", "type[WidgetProtocol]"]
 #: A generic reference to a :attr:`WidgetClass` as a string, or the class itself.
 WidgetRef = Union[str, WidgetClass]
@@ -35,8 +35,9 @@ ChoicesCallback = Callable[["CategoricalWidget[Any]"], ChoicesIterable]
 #: The set of all valid types for widget ``choices``.
 ChoicesType = Union[EnumMeta, ChoicesIterable, ChoicesCallback, ChoicesDict]
 #: A callback that may be registered for a given return annotation. When called, it will
-#: be provided an instance of a [~magicgui.widgets.FunctionGui][], the result
-#: of the function that was called, and the return annotation itself.
+#: be provided an instance of a
+#: [~magicgui.widgets.FunctionGui][magicgui.widgets.FunctionGui],
+#: the result of the function that was called, and the return annotation itself.
 ReturnCallback = Callable[["FunctionGui[Any]", Any, type], None]
 #: A valid file path type
 PathLike = Union[Path, str, bytes]

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -382,8 +382,9 @@ class RadioButtons(CategoricalWidget, _OrientationMixin):  # type: ignore
 class Container(ContainerWidget[WidgetVar]):
     """A Widget to contain other widgets.
 
-    Note that `Container` implements the [`typing.MutableSequence`][] interface,
-    so you can use it like a list to add and remove widgets.
+    Note that `Container` implements the
+    [`typing.MutableSequence`][typing.MutableSequence]
+    interface, so you can use it like a list to add and remove widgets.
     """
 
 

--- a/src/magicgui/widgets/_function_gui.py
+++ b/src/magicgui/widgets/_function_gui.py
@@ -265,7 +265,7 @@ class FunctionGui(Container, Generic[_R]):
 
     @property
     def return_annotation(self) -> Any:
-        """Return annotation to use when converting to [inspect.Signature][].
+        """Return annotation for [inspect.Signature][inspect.Signature] conversion.
 
         ForwardRefs will be resolve when setting the annotation.
         """
@@ -488,7 +488,7 @@ def _function_name_pointing_to_widget(function_gui: FunctionGui) -> Iterator[Non
     In standard `@magicgui` usage, this will have been the case anyway.
     Doing this here allows the function name in a `@magic_factory`-decorated function
     to *also* refer to the function gui instance created by the factory, (rather than
-    to the [~magicgui._magicgui.MagicFactory][] object).
+    to the [~magicgui._magicgui.MagicFactory][magicgui._magicgui.MagicFactory] object).
 
     Examples
     --------

--- a/src/magicgui/widgets/_image/_image.py
+++ b/src/magicgui/widgets/_image/_image.py
@@ -170,7 +170,7 @@ class Image(ValueWidget):
         self._widget._mgui_set_value(self._image.make_image())
 
     def __repr__(self) -> str:
-        """Return representation of widget of instsance."""
+        """Return representation of widget of instance."""
         d = self.image_data
         shape = "x".join(map(str, d.shape)) if d is not None else "<no data>"
         return f"{self.widget_type}({shape}, name={self.name!r})"

--- a/src/magicgui/widgets/_table.py
+++ b/src/magicgui/widgets/_table.py
@@ -160,8 +160,8 @@ class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
         ``tuple(range(len(data[0])))``.  Values provided here override any implied in
         ``value``.
     **kwargs
-        Additional kwargs will be passed to the [magicgui.widgets.Widget][]
-        constructor.
+        Additional kwargs will be passed to the
+        [magicgui.widgets.Widget][magicgui.widgets.Widget] constructor.
 
     Attributes
     ----------

--- a/src/magicgui/widgets/_table.py
+++ b/src/magicgui/widgets/_table.py
@@ -205,7 +205,7 @@ class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
         Emitted whenever a cell in the table changes. The value will have a
         dict of information regarding the cell that changed:
         {'data': x, 'row': int, 'column': int, 'column_header': str, 'row_header': str}
-        CURRENTLY: only emitted on changes in the GUI. not programattic changes.
+        CURRENTLY: only emitted on changes in the GUI. not programmatic changes.
     """
 
     _widget: TableWidgetProtocol

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -33,7 +33,7 @@ class ButtonWidget(ValueWidget[bool]):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.ButtonWidgetProtocol

--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -30,7 +30,7 @@ class CategoricalWidget(ValueWidget[T]):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.CategoricalWidgetProtocol

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -44,16 +44,18 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
     (`container[0]`), as well as by widget name (`container.<widget_name>`). Widgets can
     be added with `append` or `insert`, and removed with `del` or `pop`, etc...
 
-    There is a tight connection between a `ContainerWidget` and an [inspect.Signature][]
-    object, just as there is a tight connection between individual [Widget` objects an
-    an :class:`inspect.Parameter][] object. The signature representation of a
-    `ContainerWidget` (with the current settings as default values) is accessible with
+    There is a tight connection between a `ContainerWidget` and an
+    [inspect.Signature][inspect.Signature] object,
+    just as there is a tight connection between individual [Widget` objects an
+    an :class:`inspect.Parameter][inspect.Parameter] object.
+    The signature representation of a `ContainerWidget`
+    (with the current settings as default values) is accessible with
     the :meth:`~ContainerWidget.__signature__` method (or by using
     :func:`inspect.signature` from the standard library)
 
     For a `ContainerWidget` subclass that is tightly coupled to a specific function
     signature (as in the "classic" magicgui decorator), see
-    [magicgui.widgets.FunctionGui][].
+    [magicgui.widgets.FunctionGui][magicgui.widgets.FunctionGui].
 
     Parameters
     ----------
@@ -72,7 +74,7 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
         `widget.name`, but can be overridden by setting `widget.label`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     changed = Signal(

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -196,7 +196,7 @@ class RangedWidget(ValueWidget[T]):
 
 
 class TransformedRangedWidget(RangedWidget[float], ABC):
-    """Widget with a contstrained value. Wraps RangedWidgetProtocol.
+    """Widget with a constrained value. Wraps RangedWidgetProtocol.
 
     This can be used to map one domain of numbers onto another, useful for creating
     things like LogSliders.  Subclasses must reimplement ``_value_from_position`` and

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -42,7 +42,7 @@ class RangedWidget(ValueWidget[T]):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.RangedWidgetProtocol
@@ -226,7 +226,7 @@ class TransformedRangedWidget(RangedWidget[float], ABC):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.RangedWidgetProtocol

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 class SliderWidget(RangedWidget[T], _OrientationMixin):
-    """Widget with a contstrained value and orientation. Wraps SliderWidgetProtocol.
+    """Widget with a constrained value and orientation. Wraps SliderWidgetProtocol.
 
     Parameters
     ----------

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -44,7 +44,7 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.SliderWidgetProtocol

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -97,7 +97,7 @@ class ValueWidget(Widget, Generic[T]):
         return self._widget._mgui_set_value(value)
 
     def __repr__(self) -> str:
-        """Return representation of widget of instsance."""
+        """Return representation of widget of instance."""
         try:
             val = self.value if self._bound_value is Undefined else self._bound_value
             return (

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -32,7 +32,7 @@ class ValueWidget(Widget, Generic[T]):
         If `True`, the widget will accepts `None` as a valid value, by default `False`.
     **base_widget_kwargs : Any
         All additional keyword arguments are passed to the base
-        [`magicgui.widgets.Widget`][] constructor.
+        [`magicgui.widgets.Widget`][magicgui.widgets.Widget] constructor.
     """
 
     _widget: protocols.ValueWidgetProtocol

--- a/src/magicgui/widgets/bases/_widget.py
+++ b/src/magicgui/widgets/bases/_widget.py
@@ -366,7 +366,7 @@ class Widget:
         return self._widget._mgui_render()
 
     def __repr__(self) -> str:
-        """Return representation of widget of instsance."""
+        """Return representation of widget of instance."""
         return f"{self.widget_type}(annotation={self.annotation!r}, name={self.name!r})"
 
     def _repr_png_(self) -> bytes | None:

--- a/src/magicgui/widgets/protocols.py
+++ b/src/magicgui/widgets/protocols.py
@@ -1,8 +1,9 @@
 """Protocols (interfaces) for backends to implement.
 
-Each class in this module is a [typing.Protocol][] that specifies a set of
-:func:`~abc.abstractmethod` that a backend widget must implement to be compatible with
-the magicgui API.  All magicgui-specific abstract methods are prefaced with ``_mgui_*``.
+Each class in this module is a [typing.Protocol][typing.Protocol] that specifies
+a set of :func:`~abc.abstractmethod` that a backend widget must implement
+to be compatible with the magicgui API.
+All magicgui-specific abstract methods are prefaced with ``_mgui_*``.
 
 For an example backend implementation, see ``magicgui.backends._qtpy.widgets``
 """


### PR DESCRIPTION
Closes https://github.com/pyapp-kit/magicgui/issues/584

Previously with just plain mkdocs involved, links to functions/classes/etc. would automatically resolve, even when nothing was written between the second set of square brackets. So, this used to work, and you could click it in the built HTML docs and be taken to the corresponding magicgui.widgets.Container page:
```
... documentation text mentioning [magicgui.widgets.Container][]
```

But when we combined mkdocs and mkdocs-gallery (to make [our examples gallery](https://github.com/pyapp-kit/magicgui/pull/571)) it stopped automatically resolving those links for us in the docs. I'm not sure why that happens, but the quickest solution is to explicitly specify the link each time. This PR does just that.


###  summary
- Documentation: Fix hyperlinks broken by PR https://github.com/pyapp-kit/magicgui/pull/571)
- Code formatting: Slight edits to ensure code line lengths do not exceed 100 characters
