### PR TITLE
MAINT: Add pint as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "psygnal>=0.5.0",
         "qtpy>=1.7.0",
         "superqt>=0.5.0",
+        "pint",
         "typing_extensions",
     ],
 )


### PR DESCRIPTION
On my system `pip intstall magicgui` followed by running a variant of the "all of these" example from https://pyapp-kit.github.io/magicgui/widgets/#magicgui I got:
```
monolith:Desktop larsoner$ python -ui magic.py 
Traceback (most recent call last):
  File "/Applications/MNE-Python/1.5.0_1/.mne-python/lib/python3.11/site-packages/superqt/spinbox/_quantity.py", line 4, in <module>
    from pint import Quantity, Unit, UnitRegistry
ModuleNotFoundError: No module named 'pint'

The above exception was the direct cause of the following exception:

...
  File "/Applications/MNE-Python/1.5.0_1/.mne-python/lib/python3.11/site-packages/superqt/__init__.py", line 57, in __getattr__
    from .spinbox._quantity import QQuantity
  File "/Applications/MNE-Python/1.5.0_1/.mne-python/lib/python3.11/site-packages/superqt/spinbox/_quantity.py", line 7, in <module>
    raise ImportError(
ImportError: pint is required to use QQuantity.  Install it with `pip install pint`
```
I guess `pint` is an optional dependency for `superqt` (?) but it seems like `magicgui` should require it to make sure all examples work out of the box.