### PR TITLE
feat: add icons on buttons

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -98,7 +98,7 @@ jobs:
           python-version: "3.10"
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip pytest-pretty
           python -m pip install -e .[testing]
           python -m pip install -e ./napari-from-github[pyqt5]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "docstring_parser>=0.7",
     "psygnal>=0.5.0",
     "qtpy>=1.7.0",
-    "superqt>=0.5.0",
+    "superqt[iconify]>=0.6.1",
     "typing_extensions",
 ]
 
@@ -49,7 +49,7 @@ min-req = [
     "docstring_parser==0.7",
     "psygnal==0.5.0",
     "qtpy==1.7.0",
-    "superqt==0.5.0",
+    "superqt==0.6.1",
     "typing_extensions",
 ]
 

--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -260,11 +260,24 @@ class _IPySupportsText(protocols.SupportsText):
         return self._ipywidget.description
 
 
+class _IPySupportsIcon(protocols.SupportsIcon):
+    """Widget that can show an icon."""
+
+    _ipywidget: ipywdg.Widget
+
+    def _mgui_set_icon(self, value: str, color: str) -> None:
+        """Set icon."""
+        # not all ipywidget buttons support icons (like checkboxes),
+        # but our button protocol does.
+        if hasattr(self._ipywidget, "icon"):
+            self._ipywidget.icon = value.replace("fa-", "")
+
+
 class _IPyCategoricalWidget(_IPyValueWidget, _IPySupportsChoices):
     pass
 
 
-class _IPyButtonWidget(_IPyValueWidget, _IPySupportsText):
+class _IPyButtonWidget(_IPyValueWidget, _IPySupportsText, _IPySupportsIcon):
     pass
 
 

--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -266,7 +266,7 @@ class _IPySupportsIcon(protocols.SupportsIcon):
 
     _ipywidget: ipywdg.Button
 
-    def _mgui_set_icon(self, value: str, color: str) -> None:
+    def _mgui_set_icon(self, value: str | None, color: str | None) -> None:
         """Set icon."""
         # only ipywdg.Button actually supports icons.
         # but our button protocol allows it for all buttons subclasses
@@ -277,6 +277,7 @@ class _IPySupportsIcon(protocols.SupportsIcon):
             # which works for iconify icons served by qt, while still
             # allowing for bare "icon-name" syntax which works for ipywidgets.
             # note however... only fa4/5 icons will work for ipywidgets.
+            value = value or ""
             self._ipywidget.icon = value.replace("fa-", "").split(":", 1)[-1]
             self._ipywidget.style.text_color = color
 

--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -1,3 +1,5 @@
+# from __future__ import annotations  # NO
+
 from typing import Any, Callable, Iterable, Optional, Tuple, Type, Union
 
 try:
@@ -266,7 +268,7 @@ class _IPySupportsIcon(protocols.SupportsIcon):
 
     _ipywidget: ipywdg.Button
 
-    def _mgui_set_icon(self, value: str | None, color: str | None) -> None:
+    def _mgui_set_icon(self, value: Optional[str], color: Optional[str]) -> None:
         """Set icon."""
         # only ipywdg.Button actually supports icons.
         # but our button protocol allows it for all buttons subclasses

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -419,10 +419,12 @@ class QBaseRangedWidget(QBaseValueWidget, protocols.RangedWidgetProtocol):
 # BUTTONS
 
 
-class QBaseButtonWidget(QBaseValueWidget, protocols.SupportsText):
+class QBaseButtonWidget(
+    QBaseValueWidget, protocols.SupportsText, protocols.SupportsIcon
+):
     _qwidget: QtW.QCheckBox | QtW.QPushButton | QtW.QRadioButton | QtW.QToolButton
 
-    def __init__(self, qwidg: type[QtW.QWidget], **kwargs: Any) -> None:
+    def __init__(self, qwidg: type[QtW.QAbstractButton], **kwargs: Any) -> None:
         super().__init__(qwidg, "isChecked", "setChecked", "toggled", **kwargs)
 
     def _mgui_set_text(self, value: str) -> None:
@@ -432,6 +434,9 @@ class QBaseButtonWidget(QBaseValueWidget, protocols.SupportsText):
     def _mgui_get_text(self) -> str:
         """Get text."""
         return self._qwidget.text()
+
+    def _mgui_set_icon(self, value: str, color: str | None) -> None:
+        self._qwidget.setIcon(superqt.QIconifyIcon(value, color=color))
 
 
 class PushButton(QBaseButtonWidget):

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -465,11 +465,13 @@ def _get_qicon(key: str | None, color: str | None, palette: QPalette) -> QIcon |
     if not color or color == "auto":
         # use foreground color
         color = palette.color(QPalette.ColorRole.WindowText).name()
+        # don't use full black or white
+        color = {"#000000": "#333333", "#ffffff": "#cccccc"}.get(color, color)
 
     if ":" not in key:
         # for parity with the other backends, assume fontawesome
         # if no prefix is given.
-        key = f"fa-regular:{key}"
+        key = f"fa:{key}"
 
     try:
         return superqt.QIconifyIcon(key, color=color)

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -457,6 +457,11 @@ class QBaseButtonWidget(
             pal = self._qwidget.palette()
             color = pal.color(QPalette.ColorRole.WindowText).name()
 
+        if ":" not in value:
+            # for parity with the other backends, assume fontawesome
+            # if no prefix is given.
+            value = f"fa-regular:{value}"
+
         try:
             self._qwidget.setIcon(superqt.QIconifyIcon(value, color=color))
         except (OSError, ValueError) as e:

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -94,5 +94,5 @@ class ButtonWidget(ValueWidget[bool]):
         """Alias for changed event."""
         return self.changed
 
-    def set_icon(self, value: str, color: str | None) -> None:
-        self._widget._mgui_set_icon(str(value), color)
+    def set_icon(self, value: str | None, color: str | None = None) -> None:
+        self._widget._mgui_set_icon(value, color)

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -48,6 +48,8 @@ class ButtonWidget(ValueWidget[bool]):
         value: bool | _Undefined = Undefined,
         *,
         text: str | None = None,
+        icon: str | None = None,
+        icon_color: str | None = None,
         bind: bool | Callable[[ValueWidget], bool] | _Undefined = Undefined,
         nullable: bool = False,
         **base_widget_kwargs: Any,
@@ -68,6 +70,8 @@ class ButtonWidget(ValueWidget[bool]):
             value=value, bind=bind, nullable=nullable, **base_widget_kwargs
         )
         self.text = (text or self.name).replace("_", " ")
+        if icon:
+            self.set_icon(icon, icon_color)
 
     @property
     def options(self) -> dict:
@@ -89,3 +93,6 @@ class ButtonWidget(ValueWidget[bool]):
     def clicked(self) -> SignalInstance:
         """Alias for changed event."""
         return self.changed
+
+    def set_icon(self, value: str, color: str | None) -> None:
+        self._widget._mgui_set_icon(str(value), color)

--- a/src/magicgui/widgets/protocols.py
+++ b/src/magicgui/widgets/protocols.py
@@ -442,8 +442,13 @@ class SupportsIcon(Protocol):
     """Widget that can be reoriented."""
 
     @abstractmethod
-    def _mgui_set_icon(self, value: str, color: str | None) -> None:
-        """Set icon. Value is a font-awesome v5 icon name."""
+    def _mgui_set_icon(self, value: str | None, color: str | None) -> None:
+        """Set icon.
+
+        Value is an "prefix:name" from iconify: https://icon-sets.iconify.design
+        Color is any valid CSS color string.
+        Set value to `None` or an empty string to remove icon.
+        """
 
 
 @runtime_checkable

--- a/src/magicgui/widgets/protocols.py
+++ b/src/magicgui/widgets/protocols.py
@@ -438,7 +438,16 @@ class SupportsText(Protocol):
 
 
 @runtime_checkable
-class ButtonWidgetProtocol(ValueWidgetProtocol, SupportsText, Protocol):
+class SupportsIcon(Protocol):
+    """Widget that can be reoriented."""
+
+    @abstractmethod
+    def _mgui_set_icon(self, value: str, color: str | None) -> None:
+        """Set icon. Value is a font-awesome v5 icon name."""
+
+
+@runtime_checkable
+class ButtonWidgetProtocol(ValueWidgetProtocol, SupportsText, SupportsIcon, Protocol):
     """The "value" in a ButtonWidget is the current (checked) state."""
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -812,7 +812,7 @@ def test_pushbutton_click_signal():
 def test_pushbutton_icon(backend: str):
     use_app(backend)
     btn = widgets.PushButton(icon="mdi:folder")
-    btn.set_icon("smile", "red")
+    btn.set_icon("play", "red")
     btn.set_icon(None)
 
     if backend == "qt":

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -809,6 +809,17 @@ def test_pushbutton_click_signal():
     mock2.assert_called_once()
 
 
+def test_pushbutton_icon(backend: str):
+    use_app(backend)
+    btn = widgets.PushButton(icon="mdi:folder")
+    btn.set_icon("smile", "red")
+    btn.set_icon(None)
+
+    if backend == "qt":
+        with pytest.warns(UserWarning, match="Could not set iconify icon"):
+            btn.set_icon("bad:key")
+
+
 def test_list_edit():
     """Test ListEdit."""
     from typing import List


### PR DESCRIPTION
this PR allows adding icons to buttons, it uses superqt's recently added iconify support (https://github.com/pyapp-kit/superqt/pull/209) and ipywidget's built in support for fontawesome 5.  So you can do something like this:

```python
from magicgui import widgets

btn = widgets.PushButton(icon="bi:cloud")
btn.show(run=True)
```

Note that qt will have the full selection of [all icons available in iconify](https://icon-sets.iconify.design), but ipywidgets only works when the icon string after the colon is valid in fontawesome 4/5. In some cases (if you don't use font-awesome prefix as shown in the example above) that will mean a different appearance in qt.  If you want the icons to look similar in both backends, just restrict yourself to [fontawesome-5](https://icon-sets.iconify.design/fa-solid/)

| qt | ipwidgets|
|---|---------|
|<img width="162" alt="Screen Shot 2023-10-10 at 1 18 29 PM" src="https://github.com/pyapp-kit/magicgui/assets/1609449/50e8dbd6-23d4-4bb2-ac91-0a4eecb8dc6b">| <img width="166" alt="Screen Shot 2023-10-10 at 1 19 53 PM" src="https://github.com/pyapp-kit/magicgui/assets/1609449/6ab964b8-8c38-4723-a7e6-c2632d3c4dcb">|
