### PR TITLE
style: use `Unpack` for better kwargs typing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -98,7 +98,7 @@ jobs:
           python-version: "3.10"
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip pytest-pretty
           python -m pip install -e .[testing]
           python -m pip install -e ./napari-from-github[pyqt5]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["gui", "widgets", "type annotations"]
 readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
-authors = [{ email = "talley.lambert@gmail.com" }, { name = "Talley Lambert" }]
+authors = [{ email = "talley.lambert@gmail.com", name = "Talley Lambert" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: X11 Applications :: Qt",
@@ -31,7 +31,6 @@ classifiers = [
     "Topic :: Software Development :: User Interfaces",
     "Topic :: Software Development :: Widget Sets",
     "Topic :: Utilities",
-
 ]
 dynamic = ["version"]
 dependencies = [
@@ -230,6 +229,7 @@ disallow_any_generics = false
 disallow_subclassing_any = false
 show_error_codes = true
 pretty = true
+enable_incomplete_feature = ['Unpack']
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/magicgui/signature.py
+++ b/src/magicgui/signature.py
@@ -22,8 +22,12 @@ from typing_extensions import Annotated, get_args, get_origin
 from magicgui.types import Undefined
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.application import AppRef
     from magicgui.widgets import Container, Widget
+    from magicgui.widgets.bases._container_widget import ContainerKwargs
+
 TZ_EMPTY = "__no__default__"
 
 
@@ -229,14 +233,14 @@ class MagicSignature(inspect.Signature):
             {n: p.to_widget(app) for n, p in self.parameters.items()}
         )
 
-    def to_container(self, **kwargs: Any) -> Container:
+    def to_container(
+        self, app: AppRef | None = None, **kwargs: Unpack[ContainerKwargs]
+    ) -> Container:
         """Return a ``magicgui.widgets.Container`` for this MagicSignature."""
         from magicgui.widgets import Container
 
-        return Container(
-            widgets=list(self.widgets(kwargs.get("app")).values()),
-            **kwargs,
-        )
+        kwargs["widgets"] = list(self.widgets(app).values())
+        return Container(**kwargs)
 
     def replace(  # type: ignore[override]
         self,

--- a/src/magicgui/type_map/_magicgui.py
+++ b/src/magicgui/type_map/_magicgui.py
@@ -413,6 +413,9 @@ def magic_factory(
     )
 
 
+MAGICGUI_PARAMS = inspect.signature(magicgui).parameters
+
+
 # _R is the return type of the decorated function
 # _T is the type of the FunctionGui instance (FunctionGui or MainFunctionGui)
 class MagicFactory(partial, Generic[_R, _T]):
@@ -467,11 +470,10 @@ class MagicFactory(partial, Generic[_R, _T]):
 
     def __repr__(self) -> str:
         """Return string repr."""
-        params = inspect.signature(magicgui).parameters
         args = [
             f"{k}={v!r}"
             for (k, v) in self.keywords.items()
-            if v not in (params[k].default, {})
+            if v not in (MAGICGUI_PARAMS[k].default, {})
         ]
         return f"MagicFactory({', '.join(args)})"
 
@@ -479,10 +481,12 @@ class MagicFactory(partial, Generic[_R, _T]):
         """Call the wrapped _magicgui and return a FunctionGui."""
         if args:
             raise ValueError("MagicFactory instance only accept keyword arguments")
-        params = inspect.signature(magicgui).parameters
+
         factory_kwargs = self.keywords.copy()
         prm_options = factory_kwargs.pop("param_options", {})
-        prm_options.update({k: kwargs.pop(k) for k in list(kwargs) if k not in params})
+        prm_options.update(
+            {k: kwargs.pop(k) for k in list(kwargs) if k not in MAGICGUI_PARAMS}
+        )
         widget = self.func(param_options=prm_options, **{**factory_kwargs, **kwargs})
         if self._widget_init is not None:
             self._widget_init(widget)

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -54,7 +54,12 @@ from magicgui.widgets.bases import (
 from magicgui.widgets.bases._mixins import _OrientationMixin, _ReadOnlyMixin
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+    from magicgui.widgets.bases._container_widget import ContainerKwargs
+    from magicgui.widgets.bases._widget import WidgetKwargs
+
 
 WidgetVar = TypeVar("WidgetVar", bound=Widget)
 WidgetTypeVar = TypeVar("WidgetTypeVar", bound=Type[Widget])
@@ -283,17 +288,13 @@ class LogSlider(TransformedRangedWidget):
         max: float = 100,
         base: float = math.e,
         tracking: bool = True,
-        **kwargs: Any,
+        **kwargs: Unpack[WidgetKwargs],
     ):
         self._base = base
         app = use_app()
         assert app.native
-        super().__init__(
-            min=min,
-            max=max,
-            widget_type=app.get_obj("Slider"),
-            **kwargs,
-        )
+        kwargs["widget_type"] = app.get_obj("Slider")
+        super().__init__(min=min, max=max, **kwargs)
         self.tracking = tracking
 
     @property
@@ -356,7 +357,10 @@ class RadioButtons(CategoricalWidget, _OrientationMixin):  # type: ignore
     """An exclusive group of radio buttons, providing a choice from multiple choices."""
 
     def __init__(
-        self, choices: ChoicesType = (), orientation: str = "vertical", **kwargs: Any
+        self,
+        choices: ChoicesType = (),
+        orientation: str = "vertical",
+        **kwargs: Unpack[WidgetKwargs],
     ) -> None:
         app = use_app()
         assert app.native
@@ -407,9 +411,10 @@ class FileEdit(Container):
         mode: FileDialogMode = FileDialogMode.EXISTING_FILE,
         filter: str | None = None,
         nullable: bool = False,
-        **kwargs: Any,
+        **kwargs: Unpack[ContainerKwargs],
     ) -> None:
-        value = kwargs.pop("value", None)
+        # use empty string as a null value
+        value = kwargs.pop("value", None)  # type: ignore [typeddict-item]
         if value is None:
             value = ""
         self.line_edit = LineEdit(value=value)
@@ -518,9 +523,9 @@ class RangeEdit(Container[SpinBox]):
         step: int = 1,
         min: int | tuple[int, int, int] | None = None,
         max: int | tuple[int, int, int] | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[ContainerKwargs],
     ) -> None:
-        value = kwargs.pop("value", None)
+        value = kwargs.pop("value", None)  # type: ignore [typeddict-item]
         if value is not None and value is not Undefined:
             if not all(hasattr(value, x) for x in ("start", "stop", "step")):
                 raise TypeError(f"Invalid value type for {type(self)}: {type(value)}")
@@ -533,7 +538,7 @@ class RangeEdit(Container[SpinBox]):
         kwargs["widgets"] = [self.start, self.stop, self.step]
         kwargs.setdefault("layout", "horizontal")
         kwargs.setdefault("labels", True)
-        kwargs.pop("nullable", None)
+        kwargs.pop("nullable", None)  # type: ignore [typeddict-item]
         super().__init__(**kwargs)
 
     @classmethod
@@ -616,13 +621,13 @@ class ListEdit(Container[ValueWidget[_V]]):
         All additional keyword arguments are passed to `Container` constructor.
     """
 
-    def __init__(
+    def __init__(  # type: ignore [misc]  # overlap between names
         self,
         value: Iterable[_V] | _Undefined = Undefined,
         layout: str = "horizontal",
         nullable: bool = False,
         options: dict | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[ContainerKwargs],
     ) -> None:
         self._args_type: type | None = None
         self._nullable = nullable
@@ -873,14 +878,14 @@ class TupleEdit(Container[ValueWidget]):
         self,
         value: Iterable[_V] | _Undefined = Undefined,
         *,
-        layout: str = "horizontal",
         nullable: bool = False,
         options: dict | None = None,
-        **kwargs: Any,
+        **container_kwargs: Unpack[ContainerKwargs[ValueWidget]],
     ) -> None:
         self._nullable = nullable
         self._args_types: tuple[type, ...] | None = None
-        super().__init__(layout=layout, labels=False, **kwargs)
+        container_kwargs["labels"] = False
+        super().__init__(**container_kwargs)
         self._child_options = options or {}
         self.margins = (0, 0, 0, 0)
 
@@ -967,12 +972,12 @@ class TupleEdit(Container[ValueWidget]):
 class _LabeledWidget(Container):
     """Simple container that wraps a widget and provides a label."""
 
-    def __init__(
+    def __init__(  # type: ignore [misc]  # overlap between argument names
         self,
         widget: Widget,
         label: str | None = None,
         position: str = "left",
-        **kwargs: Any,
+        **kwargs: Unpack[ContainerKwargs],
     ) -> None:
         kwargs["layout"] = "horizontal" if position in {"left", "right"} else "vertical"
         self._inner_widget = widget

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -285,21 +285,6 @@ class LogSlider(TransformedRangedWidget):
         tracking: bool = True,
         **kwargs: Any,
     ):
-        # sourcery skip: avoid-builtin-shadow
-        for key in ("maximum", "minimum"):
-            if key in kwargs:
-                import warnings
-
-                warnings.warn(
-                    f"The {key!r} keyword arguments has been changed to {key[:3]!r}. "
-                    "In the future this will raise an exception\n",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-                if key == "maximum":
-                    max = kwargs.pop(key)  # noqa: A001
-                else:
-                    min = kwargs.pop(key)  # noqa: A001
         self._base = base
         app = use_app()
         assert app.native

--- a/src/magicgui/widgets/_table.py
+++ b/src/magicgui/widgets/_table.py
@@ -31,9 +31,12 @@ from magicgui.widgets.bases._value_widget import ValueWidget
 if TYPE_CHECKING:
     import numpy
     import pandas
-    from typing_extensions import TypeGuard
+    from typing_extensions import TypeGuard, Unpack
 
     from magicgui.widgets.protocols import TableWidgetProtocol
+
+    from .bases._widget import WidgetKwargs
+
 TblKey = Any
 _KT = TypeVar("_KT")  # Key type
 _KT_co = TypeVar("_KT_co", covariant=True)  # Key type covariant containers.
@@ -227,9 +230,9 @@ class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
         *,
         index: Collection | None = None,
         columns: Collection | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[WidgetKwargs],
     ) -> None:
-        super().__init__(widget_type=use_app().get_obj("Table"), **kwargs)
+        super().__init__(**{**kwargs, "widget_type": use_app().get_obj("Table")})
         self._data = DataView(self)
         data, _index, _columns = normalize_table_data(value)
         self.value = {

--- a/src/magicgui/widgets/_table.py
+++ b/src/magicgui/widgets/_table.py
@@ -232,7 +232,8 @@ class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
         columns: Collection | None = None,
         **kwargs: Unpack[WidgetKwargs],
     ) -> None:
-        super().__init__(**{**kwargs, "widget_type": use_app().get_obj("Table")})
+        kwargs["widget_type"] = use_app().get_obj("Table")
+        super().__init__(**kwargs)
         self._data = DataView(self)
         data, _index, _columns = normalize_table_data(value)
         self.value = {

--- a/src/magicgui/widgets/bases/_button_widget.py
+++ b/src/magicgui/widgets/bases/_button_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Callable
 
 from psygnal import Signal, SignalInstance
 
@@ -9,7 +9,11 @@ from magicgui.types import Undefined, _Undefined
 from ._value_widget import ValueWidget
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+
+    from ._widget import WidgetKwargs
 
 
 class ButtonWidget(ValueWidget[bool]):
@@ -50,7 +54,7 @@ class ButtonWidget(ValueWidget[bool]):
         text: str | None = None,
         bind: bool | Callable[[ValueWidget], bool] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         if text and base_widget_kwargs.get("label"):
             from warnings import warn

--- a/src/magicgui/widgets/bases/_categorical_widget.py
+++ b/src/magicgui/widgets/bases/_categorical_widget.py
@@ -8,7 +8,11 @@ from magicgui.types import ChoicesType, Undefined, _Undefined
 from ._value_widget import T, ValueWidget
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+
+    from ._widget import WidgetKwargs
 
 
 class CategoricalWidget(ValueWidget[T]):
@@ -45,7 +49,7 @@ class CategoricalWidget(ValueWidget[T]):
         allow_multiple: bool | None = None,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         if allow_multiple is not None:
             self._allow_multiple = allow_multiple

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
     Iterable,
     Mapping,
     MutableSequence,
@@ -25,6 +26,8 @@ from ._button_widget import ButtonWidget
 from ._value_widget import ValueWidget
 from ._widget import Widget
 
+WidgetVar = TypeVar("WidgetVar", bound=Widget)
+
 if TYPE_CHECKING:
     import inspect
     from pathlib import Path
@@ -35,14 +38,11 @@ if TYPE_CHECKING:
 
     from ._widget import WidgetKwargs
 
-    class ContainerKwargs(WidgetKwargs, total=False):
-        widgets: Sequence[Widget]
+    class ContainerKwargs(WidgetKwargs, Generic[WidgetVar], total=False):
+        widgets: Sequence[WidgetVar]
         layout: str
         scrollable: bool
         labels: bool
-
-
-WidgetVar = TypeVar("WidgetVar", bound=Widget)
 
 
 class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -29,7 +29,19 @@ if TYPE_CHECKING:
     import inspect
     from pathlib import Path
 
+    from typing_extensions import Unpack
+
     from magicgui.widgets import Container, protocols
+
+    from ._widget import WidgetKwargs
+
+    class ContainerKwargs(WidgetKwargs, total=False):
+        widgets: Sequence[Widget]
+        layout: str
+        scrollable: bool
+        labels: bool
+
+
 WidgetVar = TypeVar("WidgetVar", bound=Widget)
 
 
@@ -94,14 +106,13 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
         layout: str = "vertical",
         scrollable: bool = False,
         labels: bool = True,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         self._list: list[WidgetVar] = []
         self._labels = labels
         self._layout = layout
         self._scrollable = scrollable
-        base_widget_kwargs.setdefault("backend_kwargs", {})
-        base_widget_kwargs["backend_kwargs"].update(
+        base_widget_kwargs.setdefault("backend_kwargs", {}).update(  # type: ignore
             {"layout": layout, "scrollable": scrollable}
         )
         super().__init__(**base_widget_kwargs)
@@ -284,13 +295,18 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
         return MagicSignature(params)
 
     @classmethod
-    def from_signature(cls, sig: inspect.Signature, **kwargs: Any) -> Container:
+    def from_signature(
+        cls, sig: inspect.Signature, **kwargs: Unpack[ContainerKwargs]
+    ) -> Container:
         """Create a Container widget from an inspect.Signature object."""
         return MagicSignature.from_signature(sig).to_container(**kwargs)
 
     @classmethod
     def from_callable(
-        cls, obj: Callable, gui_options: dict | None = None, **kwargs: Any
+        cls,
+        obj: Callable,
+        gui_options: dict | None = None,
+        **kwargs: Unpack[ContainerKwargs],
     ) -> Container:
         """Create a Container widget from a callable object.
 

--- a/src/magicgui/widgets/bases/_ranged_widget.py
+++ b/src/magicgui/widgets/bases/_ranged_widget.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import builtins
 from abc import ABC, abstractmethod
 from math import ceil, log10
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Tuple, TypeVar, Union, cast
-from warnings import warn
+from typing import TYPE_CHECKING, Callable, Iterable, Tuple, TypeVar, Union, cast
 
 from magicgui.types import Undefined, _Undefined
 
 from ._value_widget import ValueWidget
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+
+    from ._widget import WidgetKwargs
 
 T = TypeVar("T", int, float, Tuple[Union[int, float], ...])
 DEFAULT_MIN = 0.0
@@ -56,20 +59,8 @@ class RangedWidget(ValueWidget[T]):
         step: float | _Undefined | None = Undefined,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
-    ) -> None:  # sourcery skip: avoid-builtin-shadow
-        for key in ("maximum", "minimum"):
-            if key in base_widget_kwargs:
-                warn(
-                    f"The {key!r} keyword arguments has been changed to {key[:3]!r}. "
-                    "In the future this will raise an exception\n",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-                if key == "maximum":
-                    max = base_widget_kwargs.pop(key)  # noqa: A001
-                else:
-                    min = base_widget_kwargs.pop(key)  # noqa: A001
+        **base_widget_kwargs: Unpack[WidgetKwargs],
+    ) -> None:
         # value should be set *after* min max is set
         super().__init__(
             bind=bind,  # type: ignore
@@ -242,7 +233,7 @@ class TransformedRangedWidget(RangedWidget[float], ABC):
         step: int = 1,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         self._min = min
         self._max = max

--- a/src/magicgui/widgets/bases/_slider_widget.py
+++ b/src/magicgui/widgets/bases/_slider_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Tuple, Union
 
 from magicgui.types import Undefined, _Undefined
 
@@ -8,7 +8,11 @@ from ._mixins import _OrientationMixin
 from ._ranged_widget import MultiValueRangedWidget, RangedWidget, T
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+
+    from ._widget import WidgetKwargs
 
 
 class SliderWidget(RangedWidget[T], _OrientationMixin):
@@ -61,7 +65,7 @@ class SliderWidget(RangedWidget[T], _OrientationMixin):
         tracking: bool = True,
         bind: T | Callable[[protocols.ValueWidgetProtocol], T] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         base_widget_kwargs["backend_kwargs"] = {
             "readout": readout,

--- a/src/magicgui/widgets/bases/_value_widget.py
+++ b/src/magicgui/widgets/bases/_value_widget.py
@@ -10,7 +10,11 @@ from magicgui.types import Undefined, _Undefined
 from ._widget import Widget
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from magicgui.widgets import protocols
+
+    from ._widget import WidgetKwargs
 
 T = TypeVar("T")
 
@@ -45,7 +49,7 @@ class ValueWidget(Widget, Generic[T]):
         *,
         bind: T | Callable[[ValueWidget], T] | _Undefined = Undefined,
         nullable: bool = False,
-        **base_widget_kwargs: Any,
+        **base_widget_kwargs: Unpack[WidgetKwargs],
     ) -> None:
         self._nullable = nullable
         self._bound_value = bind

--- a/src/magicgui/widgets/bases/_widget.py
+++ b/src/magicgui/widgets/bases/_widget.py
@@ -15,9 +15,27 @@ if TYPE_CHECKING:
     from weakref import ReferenceType
 
     import numpy as np
+    from typing_extensions import TypedDict
 
     from magicgui.widgets._concrete import _LabeledWidget
     from magicgui.widgets.protocols import WidgetProtocol
+
+    class WidgetKwargs(TypedDict, total=False):
+        # technically, this should be Required[type[WidgetProtocol]]]
+        # but the widget_type argument is generally provided dynamically
+        # by the @backend_widget decorator. So it appears to be missing if we require it
+        widget_type: type[WidgetProtocol]
+        name: str
+        annotation: Any | None
+        label: str | None
+        tooltip: str | None
+        visible: bool | None
+        enabled: bool
+        gui_only: bool
+        parent: Any
+        backend_kwargs: dict | None
+
+        description: str  # alias for label
 
 
 class Widget:
@@ -77,7 +95,7 @@ class Widget:
         gui_only: bool = False,
         parent: Any | None = None,
         backend_kwargs: dict | None = None,
-        **extra: Any,
+        **extra: Any,  # not really used
     ):
         # for ipywidgets API compatibility
         if backend_kwargs is None:


### PR DESCRIPTION
this PR uses Unpack to provide nicer static IDE completion for all the places where widget kwargs are passed through a chain of super calls