### PR TITLE
fix: Allow user overwritte default widget opts

### DIFF
--- a/src/magicgui/widgets/bases/_create_widget.py
+++ b/src/magicgui/widgets/bases/_create_widget.py
@@ -93,7 +93,7 @@ def create_widget(
     assert wdg.value == ""
     ```
     """
-    _options = options.copy() if options is not None else {}
+    options_ = options.copy() if options is not None else {}
     kwargs = {
         "value": value,
         "annotation": annotation,
@@ -109,21 +109,21 @@ def create_widget(
         from magicgui.type_map import get_widget_class
 
         if widget_type:
-            _options["widget_type"] = widget_type
+            options_["widget_type"] = widget_type
         # special case parameters named "password" with annotation of str
         if (
-            not _options.get("widget_type")
+            not options_.get("widget_type")
             and (name or "").lower() == "password"
             and annotation is str
         ):
-            _options["widget_type"] = "Password"
+            options_["widget_type"] = "Password"
 
         wdg_class, opts = get_widget_class(
-            value, annotation, _options, is_result, raise_on_unknown
+            value, annotation, options_, is_result, raise_on_unknown
         )
 
         if issubclass(wdg_class, Widget):
-            widget = wdg_class(**{**kwargs, **opts, **_options})
+            widget = wdg_class(**{**kwargs, **opts, **options_})
             if param_kind:
                 widget.param_kind = param_kind  # type: ignore
             return widget
@@ -133,9 +133,9 @@ def create_widget(
     for p in ("Categorical", "Ranged", "Button", "Value", ""):
         prot = getattr(protocols, f"{p}WidgetProtocol")
         if isinstance(wdg_class, prot):
-            _options = kwargs.pop("options", None)
+            options_ = kwargs.pop("options", None)
             cls = getattr(bases, f"{p}Widget")
-            widget = cls(**{**kwargs, **(_options or {}), "widget_type": wdg_class})
+            widget = cls(**{**kwargs, **(options_ or {}), "widget_type": wdg_class})
             if param_kind:
                 widget.param_kind = param_kind  # type: ignore
             return widget

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,5 +1,6 @@
 import datetime
 import inspect
+import typing
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -108,6 +109,17 @@ def test_create_widget_annotation(annotation, expected_type):
     wdg = widgets.create_widget(annotation=annotation)
     assert isinstance(wdg, expected_type)
     wdg.close()
+
+
+def test_create_widget_annotation_overwritte_parrams():
+    wdg1 = widgets.create_widget(annotation=widgets.ProgressBar)
+    assert isinstance(wdg1, widgets.ProgressBar)
+    assert wdg1.visible
+    wdg2 = widgets.create_widget(
+        annotation=typing.Annotated[widgets.ProgressBar, {"visible": False}]
+    )
+    assert isinstance(wdg2, widgets.ProgressBar)
+    assert not wdg2.visible
 
 
 # fmt: off

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,5 @@
 import datetime
 import inspect
-import typing
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Tuple
@@ -116,7 +115,7 @@ def test_create_widget_annotation_overwritte_parrams():
     assert isinstance(wdg1, widgets.ProgressBar)
     assert wdg1.visible
     wdg2 = widgets.create_widget(
-        annotation=typing.Annotated[widgets.ProgressBar, {"visible": False}]
+        annotation=Annotated[widgets.ProgressBar, {"visible": False}]
     )
     assert isinstance(wdg2, widgets.ProgressBar)
     assert not wdg2.visible


### PR DESCRIPTION
This PR fixes https://github.com/napari/napari/issues/6354

It also renamems multiple variables starting from `_` to ending with `_` as it is convention to use leading underscore as an unused variable when it is a local variable in functions so make it harder for me to follow flow of code. 