### PR TITLE
fix: allow future annotations in ipywidgets backend

### DIFF
--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -1,6 +1,6 @@
-# from __future__ import annotations  # NO
+from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, get_type_hints
 
 try:
     import ipywidgets
@@ -13,10 +13,12 @@ except ImportError as e:
 
 
 from magicgui.widgets import protocols
-from magicgui.widgets.bases import Widget
+
+if TYPE_CHECKING:
+    from magicgui.widgets.bases import Widget
 
 
-def _pxstr2int(pxstr: Union[int, str]) -> int:
+def _pxstr2int(pxstr: int | str) -> int:
     if isinstance(pxstr, int):
         return pxstr
     if isinstance(pxstr, str) and pxstr.endswith("px"):
@@ -24,7 +26,7 @@ def _pxstr2int(pxstr: Union[int, str]) -> int:
     return int(pxstr)
 
 
-def _int2pxstr(pxint: Union[int, str]) -> str:
+def _int2pxstr(pxint: int | str) -> str:
     return f"{pxint}px" if isinstance(pxint, int) else pxint
 
 
@@ -33,11 +35,11 @@ class _IPyWidget(protocols.WidgetProtocol):
 
     def __init__(
         self,
-        wdg_class: Optional[Type[ipywdg.Widget]] = None,
-        parent: Optional[ipywdg.Widget] = None,
+        wdg_class: type[ipywdg.Widget] | None = None,
+        parent: ipywdg.Widget | None = None,
     ):
         if wdg_class is None:
-            wdg_class = type(self).__annotations__.get("_ipywidget")
+            wdg_class = get_type_hints(self, None, globals()).get("_ipywidget")
         if wdg_class is None:
             raise TypeError("Must provide a valid ipywidget type")
         self._ipywidget = wdg_class()
@@ -82,20 +84,20 @@ class _IPyWidget(protocols.WidgetProtocol):
         # will this always work with our base Widget assumptions?
         return _pxstr2int(self._ipywidget.layout.width)
 
-    def _mgui_set_width(self, value: Union[int, str]) -> None:
+    def _mgui_set_width(self, value: int | str) -> None:
         """Set the current width of the widget."""
         self._ipywidget.layout.width = _int2pxstr(value)
 
     def _mgui_get_min_width(self) -> int:
         return _pxstr2int(self._ipywidget.layout.min_width)
 
-    def _mgui_set_min_width(self, value: Union[int, str]):
+    def _mgui_set_min_width(self, value: int | str):
         self._ipywidget.layout.min_width = _int2pxstr(value)
 
     def _mgui_get_max_width(self) -> int:
         return _pxstr2int(self._ipywidget.layout.max_width)
 
-    def _mgui_set_max_width(self, value: Union[int, str]):
+    def _mgui_set_max_width(self, value: int | str):
         self._ipywidget.layout.max_width = _int2pxstr(value)
 
     def _mgui_get_height(self) -> int:
@@ -125,7 +127,7 @@ class _IPyWidget(protocols.WidgetProtocol):
     def _mgui_get_tooltip(self) -> str:
         return self._ipywidget.tooltip
 
-    def _mgui_set_tooltip(self, value: Optional[str]) -> None:
+    def _mgui_set_tooltip(self, value: str | None) -> None:
         self._ipywidget.tooltip = value
 
     def _ipython_display_(self, **kwargs):
@@ -211,11 +213,11 @@ class _IPySupportsOrientation(protocols.SupportsOrientation):
 class _IPySupportsChoices(protocols.SupportsChoices):
     _ipywidget: ipywdg.Widget
 
-    def _mgui_get_choices(self) -> Tuple[Tuple[str, Any]]:
+    def _mgui_get_choices(self) -> tuple[tuple[str, Any]]:
         """Get available choices."""
         return self._ipywidget.options
 
-    def _mgui_set_choices(self, choices: Iterable[Tuple[str, Any]]) -> None:
+    def _mgui_set_choices(self, choices: Iterable[tuple[str, Any]]) -> None:
         """Set available choices."""
         self._ipywidget.options = choices
 
@@ -268,7 +270,7 @@ class _IPySupportsIcon(protocols.SupportsIcon):
 
     _ipywidget: ipywdg.Button
 
-    def _mgui_set_icon(self, value: Optional[str], color: Optional[str]) -> None:
+    def _mgui_set_icon(self, value: str | None, color: str | None) -> None:
         """Set icon."""
         # only ipywdg.Button actually supports icons.
         # but our button protocol allows it for all buttons subclasses
@@ -355,7 +357,7 @@ class ToolBar(_IPyWidget):
 
     def __init__(self, **kwargs):
         super().__init__(ipywidgets.HBox, **kwargs)
-        self._icon_sz: Optional[Tuple[int, int]] = None
+        self._icon_sz: tuple[int, int] | None = None
 
     def _mgui_add_button(self, text: str, icon: str, callback: Callable) -> None:
         """Add an action to the toolbar."""
@@ -366,7 +368,7 @@ class ToolBar(_IPyWidget):
             btn.on_click(lambda e: callback())
         self._add_ipywidget(btn)
 
-    def _add_ipywidget(self, widget: "ipywidgets.Widget") -> None:
+    def _add_ipywidget(self, widget: ipywidgets.Widget) -> None:
         children = list(self._ipywidget.children)
         children.append(widget)
         self._ipywidget.children = children
@@ -383,15 +385,15 @@ class ToolBar(_IPyWidget):
         """Add a spacer to the toolbar."""
         self._add_ipywidget(ipywdg.Box(layout=ipywdg.Layout(flex="1")))
 
-    def _mgui_add_widget(self, widget: "Widget") -> None:
+    def _mgui_add_widget(self, widget: Widget) -> None:
         """Add a widget to the toolbar."""
         self._add_ipywidget(widget.native)
 
-    def _mgui_get_icon_size(self) -> Optional[Tuple[int, int]]:
+    def _mgui_get_icon_size(self) -> tuple[int, int] | None:
         """Return the icon size of the toolbar."""
         return self._icon_sz
 
-    def _mgui_set_icon_size(self, size: Union[int, Tuple[int, int], None]) -> None:
+    def _mgui_set_icon_size(self, size: int | (tuple[int, int] | None)) -> None:
         """Set the icon size of the toolbar."""
         if isinstance(size, int):
             size = (size, size)
@@ -465,19 +467,19 @@ class Container(_IPyWidget, protocols.ContainerProtocol, protocols.SupportsOrien
         wdg_class = ipywidgets.VBox if layout == "vertical" else ipywidgets.HBox
         super().__init__(wdg_class, **kwargs)
 
-    def _mgui_add_widget(self, widget: "Widget") -> None:
+    def _mgui_add_widget(self, widget: Widget) -> None:
         children = list(self._ipywidget.children)
         children.append(widget.native)
         self._ipywidget.children = children
         widget.parent = self._ipywidget
 
-    def _mgui_insert_widget(self, position: int, widget: "Widget") -> None:
+    def _mgui_insert_widget(self, position: int, widget: Widget) -> None:
         children = list(self._ipywidget.children)
         children.insert(position, widget.native)
         self._ipywidget.children = children
         widget.parent = self._ipywidget
 
-    def _mgui_remove_widget(self, widget: "Widget") -> None:
+    def _mgui_remove_widget(self, widget: Widget) -> None:
         children = list(self._ipywidget.children)
         children.remove(widget.native)
         self._ipywidget.children = children
@@ -490,17 +492,17 @@ class Container(_IPyWidget, protocols.ContainerProtocol, protocols.SupportsOrien
     def _mgui_count(self) -> int:
         return len(self._ipywidget.children)
 
-    def _mgui_index(self, widget: "Widget") -> int:
+    def _mgui_index(self, widget: Widget) -> int:
         return self._ipywidget.children.index(widget.native)
 
-    def _mgui_get_index(self, index: int) -> Optional[Widget]:
+    def _mgui_get_index(self, index: int) -> Widget | None:
         """(return None instead of index error)."""
         return self._ipywidget.children[index]._magic_widget
 
     def _mgui_get_native_layout(self) -> Any:
         raise self._ipywidget
 
-    def _mgui_get_margins(self) -> Tuple[int, int, int, int]:
+    def _mgui_get_margins(self) -> tuple[int, int, int, int]:
         margin = self._ipywidget.layout.margin
         if margin:
             try:
@@ -510,7 +512,7 @@ class Container(_IPyWidget, protocols.ContainerProtocol, protocols.SupportsOrien
                 return margin
         return (0, 0, 0, 0)
 
-    def _mgui_set_margins(self, margins: Tuple[int, int, int, int]) -> None:
+    def _mgui_set_margins(self, margins: tuple[int, int, int, int]) -> None:
         lft, top, rgt, bot = margins
         self._ipywidget.layout.margin = f"{top}px {rgt}px {bot}px {lft}px"
 


### PR DESCRIPTION
Because the ipywidgets backend uses type hints to determine the composed widget type:

```python
class _IPyWidget(protocols.WidgetProtocol):
    _ipywidget: ipywdg.Widget
```

I access the hints at runtime.  This makes that more robust and allows `__future__` annotations 