### PR TITLE
feat: add `Table.delete_row` method

### DIFF
--- a/src/magicgui/widgets/_table.py
+++ b/src/magicgui/widgets/_table.py
@@ -269,6 +269,39 @@ class Table(ValueWidget, _ReadOnlyMixin, MutableMapping[TblKey, list]):
         for row, d in enumerate(data):
             self._set_rowi(row, d)
 
+    def delete_row(
+        self,
+        *,
+        index: int | Sequence[int] | None = None,
+        header: Any | Sequence[Any] | None = None,
+    ) -> None:
+        """Delete row(s) by index or header.
+
+        Parameters
+        ----------
+        index : int or Sequence[int], optional
+            Index or indices of row(s) to delete.
+        header : Any or Sequence[Any], optional
+            Header or headers of row(s) to delete.
+        """
+        indices: set[int] = set()
+        if index is not None:
+            if isinstance(index, Sequence):
+                indices.update(index)
+            else:
+                indices.add(index)
+        if header is not None:
+            if isinstance(header, str) or not isinstance(header, Sequence):
+                header = (header,)
+            row_headers = self.row_headers
+            for h in header:
+                try:
+                    indices.add(row_headers.index(h))
+                except ValueError as e:
+                    raise KeyError(f"{h!r} is not a valid row header") from e
+        for i in sorted(indices, reverse=True):
+            self._del_rowi(i)
+
     @property
     def data(self) -> DataView:
         """Return DataView object for this table."""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,7 +1,6 @@
 """Tests for the Table widget."""
 import os
 import sys
-from numpy import delete
 
 import pytest
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,6 +1,7 @@
 """Tests for the Table widget."""
 import os
 import sys
+from numpy import delete
 
 import pytest
 
@@ -396,3 +397,12 @@ def test_item_delegate(qapp):
     data = ["1.2", "1.23456789", "0.000123", "1234567", "0.0", "1", "s"]
     results = [_format_number(v, 4) for v in data]
     assert results == ["1.2000", "1.2346", "1.230e-04", "1.235e+06", "0.0000", "1", "s"]
+
+
+def test_row_delete(qapp) -> None:
+    table = Table(value=_TABLE_DATA["split"])
+    assert table.data.to_list() == [[1, 2, 3], [4, 5, 6]]
+    table.delete_row(index=0)
+    assert table.data.to_list() == [[4, 5, 6]]
+    table.delete_row(header="r2")
+    assert table.data.to_list() == []


### PR DESCRIPTION
cc @jni 

would appreciate your input on the API.  I considered using `Table.drop` like the pandas API, but I thought it might be confusing that this one is in-place and that one is not.  I'm also wary of the confusion between row indices and row headers (both of which could conceivably be integers), so I forced the usage of a kwarg.
