### PR TITLE
docs: unpin pyside6 when building docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "qtgallery",
     # extras for all the widgets
     "napari ==0.4.18",
-    "pyside6 ==6.4.2",    # 6.4.3 gives segfault for some reason
+    "pyside6",
     "pint",
     "matplotlib",
     "ipywidgets >=8.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "qtgallery",
     # extras for all the widgets
     "napari ==0.4.18",
-    "pyside6",
+    "pyqt6",
     "pint",
     "matplotlib",
     "ipywidgets >=8.0.0",


### PR DESCRIPTION
for some reason, it's no longer able to install pyside6==6.4.2 when building docs