### PR TITLE
Ensure QImage is ARGB32 before converting to numpy

### DIFF
--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -181,6 +181,8 @@ class QBaseWidget(protocols.WidgetProtocol):
             ) from None
 
         img = self._qwidget.grab().toImage()
+        if img.format() != QImage.Format_ARGB32:
+            img = img.convertToFormat(QImage.Format_ARGB32)
         bits = img.constBits()
         h, w, c = img.height(), img.width(), 4
         if qtpy.API_NAME.startswith("PySide"):


### PR DESCRIPTION
Closes #617 

Thanks for pointing out the fix in napari - I just copied the code from there. I think `convertTo` might avoid the copy when unnecessary as well, but it was introduced in 5.13 so this seems safer.