### PR TITLE
Add Separator to ComboBox

### DIFF
--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -221,7 +221,6 @@ class _IPySupportsChoices(protocols.SupportsChoices):
     def _mgui_set_choices(self, choices: Iterable[tuple[str, Any]]) -> None:
         """Set available choices."""
         options = [item for item in choices if item[1] is not Separator]
-        options = list(dict(options).items())  # remove duplicate names, last data used
         self._ipywidget.options = options
 
     def _mgui_del_choice(self, choice_name: str) -> None:

--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -12,6 +12,7 @@ except ImportError as e:
     ) from e
 
 
+from magicgui.types import Separator
 from magicgui.widgets import protocols
 
 if TYPE_CHECKING:
@@ -219,7 +220,9 @@ class _IPySupportsChoices(protocols.SupportsChoices):
 
     def _mgui_set_choices(self, choices: Iterable[tuple[str, Any]]) -> None:
         """Set available choices."""
-        self._ipywidget.options = choices
+        options = [item for item in choices if item[1] is not Separator]
+        options = list(dict(options).items())  # remove duplicate names, last data used
+        self._ipywidget.options = options
 
     def _mgui_del_choice(self, choice_name: str) -> None:
         """Delete a choice."""
@@ -248,7 +251,7 @@ class _IPySupportsChoices(protocols.SupportsChoices):
 
     def _mgui_set_choice(self, choice_name: str, data: Any) -> None:
         """Set the data associated with a choice."""
-        self._ipywidget.options = (*self._ipywidget.options, (choice_name, data))
+        pass
 
 
 class _IPySupportsText(protocols.SupportsText):

--- a/src/magicgui/backends/_ipynb/widgets.py
+++ b/src/magicgui/backends/_ipynb/widgets.py
@@ -250,7 +250,7 @@ class _IPySupportsChoices(protocols.SupportsChoices):
 
     def _mgui_set_choice(self, choice_name: str, data: Any) -> None:
         """Set the data associated with a choice."""
-        pass
+        self._ipywidget.options = (*self._ipywidget.options, (choice_name, data))
 
 
 class _IPySupportsText(protocols.SupportsText):

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -954,9 +954,8 @@ class ComboBox(QBaseValueWidget, protocols.CategoricalWidgetProtocol):
                     self._qwidget.removeItem(i)
             # update choices and insert separators
             for name, data in choices_:
-                if isinstance(data, Separator):
-                    for _ in range(data.thickness):
-                        self._qwidget.insertSeparator(self._mgui_get_count())
+                if data is Separator:
+                    self._qwidget.insertSeparator(self._mgui_get_count())
                 else:
                     self._mgui_set_choice(name, data)
 

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -26,7 +26,7 @@ from qtpy.QtGui import (
     QTextDocument,
 )
 
-from magicgui.types import FileDialogMode
+from magicgui.types import FileDialogMode, Separator
 from magicgui.widgets import Widget, protocols
 from magicgui.widgets._concrete import _LabeledWidget
 
@@ -952,9 +952,13 @@ class ComboBox(QBaseValueWidget, protocols.CategoricalWidgetProtocol):
             for i in reversed(range(self._qwidget.count())):
                 if self._qwidget.itemText(i) not in choice_names:
                     self._qwidget.removeItem(i)
-            # update choices
+            # update choices and insert separators
             for name, data in choices_:
-                self._mgui_set_choice(name, data)
+                if isinstance(data, Separator):
+                    for _ in range(data.thickness):
+                        self._qwidget.insertSeparator(self._mgui_get_count())
+                else:
+                    self._mgui_set_choice(name, data)
 
             # if the currently selected item is not in the new set,
             # remove it and select the first item in the list

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -908,8 +908,12 @@ class ComboBox(QBaseValueWidget, protocols.CategoricalWidgetProtocol):
         self._event_filter.valueChanged.connect(callback)
 
     def _mgui_get_count(self) -> int:
-        """Return the number of items in the dropdown, including separator items."""
-        return self._qwidget.count()
+        """Return the number of items in the dropdown, omitting any separator items."""
+        return sum(
+            1
+            for i in range(self._qwidget.count())
+            if self._qwidget.itemData(i) != Separator
+        )
 
     def _mgui_get_choice(self, choice_name: str) -> Any:
         item_index = self._qwidget.findText(choice_name)
@@ -931,7 +935,7 @@ class ComboBox(QBaseValueWidget, protocols.CategoricalWidgetProtocol):
     def _mgui_set_choice(self, choice_name: str, data: Any) -> None:
         """Set data for ``choice_name``."""
         if data is Separator:
-            item_index = self._mgui_get_count()
+            item_index = self._qwidget.count()
             self._qwidget.insertSeparator(item_index)  # itemData is None
             self._qwidget.setItemData(item_index, Separator)
         else:

--- a/src/magicgui/schema/_guiclass.py
+++ b/src/magicgui/schema/_guiclass.py
@@ -257,7 +257,7 @@ def bind_gui_to_instance(
     if isinstance(events, SignalGroup):
         # psygnal >=0.10
         if hasattr(events, "__iter__") and hasattr(events, "__getitem__"):
-            signals = {k: events[k] for k in events}  # type: ignore
+            signals = {k: events[k] for k in events}
         else:  # psygnal <0.10
             signals = events.signals
 

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -81,6 +81,13 @@ class _Undefined:
 
 Undefined = _Undefined()
 
+class Separator:
+    """Separator sentinel for ComboBox choices."""
+
+    def __init__(self, thickness: int = 1):
+        self.thickness: int = thickness
+
+
 JsonStringFormats = Literal[
     # ISO 8601 format.
     # https://www.iso.org/iso-8601-date-and-time-format.html

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -81,11 +81,27 @@ class _Undefined:
 
 Undefined = _Undefined()
 
-class Separator:
-    """Separator sentinel for ComboBox choices."""
 
-    def __init__(self, thickness: int = 1):
-        self.thickness: int = thickness
+class _Separator:
+    """Sentinel class to separate groups of items in a ComboBox.
+
+    Example: ``choices=[1, 2, 3, Separator, Separator, 4, Separator]``
+
+    ``_Separator`` is a singleton.
+    """
+
+    _instance: _Separator | None = None
+
+    def __new__(cls) -> _Separator:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "<Separator>"
+
+
+Separator = _Separator()
 
 
 JsonStringFormats = Literal[

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -342,7 +342,7 @@ class LogSlider(TransformedRangedWidget):
 
 @backend_widget
 class ComboBox(CategoricalWidget):
-    """A dropdown menu allowing ``Separator`` and selection between multiple choices."""
+    """A dropdown menu, allowing selection between multiple choices."""
 
 
 @backend_widget

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -342,7 +342,7 @@ class LogSlider(TransformedRangedWidget):
 
 @backend_widget
 class ComboBox(CategoricalWidget):
-    """A dropdown menu, allowing selection between multiple choices."""
+    """A dropdown menu allowing ``Separator`` and selection between multiple choices."""
 
 
 @backend_widget

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1059,6 +1059,37 @@ def test_literal():
     assert sel.choices == get_args(Lit)
 
 
+def test_separator_default():
+    from magicgui.types import Separator
+
+    sep = Separator()
+    assert sep.thickness == 1
+
+
+def test_separator():
+    from magicgui.types import Separator
+
+    sep = [Separator(i + 1) for i in range(4)]
+    a = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 11, 12, sep[0], 14, sep[0]]
+    b = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 6, 7, sep[0], 9, sep[0]]
+    a2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, 11, 12, None, 14, None)
+    b2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, None, None)
+
+    @magicgui(
+        call_button="Test Separator",
+        a={"widget_type": "ComboBox", "choices": a},
+        b={"widget_type": "ComboBox", "choices": b},
+        result_widget=True,
+    )
+    def widget_with_separator(a=a[0], b=b[0]):
+        return
+
+    assert widget_with_separator.a.native.count() == 21
+    assert widget_with_separator.b.native.count() == 18
+    assert widget_with_separator.a.choices == a2
+    assert widget_with_separator.b.choices == b2
+
+
 def test_float_slider_readout():
     sld = widgets.FloatSlider(value=4, min=0.5, max=10.5)
     assert sld.value == 4

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1067,8 +1067,10 @@ def test_separator_singleton():
     assert sep1 is sep2
 
 
-def test_separator():
+def test_separator(backend: str):
     from magicgui.types import Separator
+
+    use_app(backend)
 
     sep = [[Separator] * (i + 1) for i in range(4)]
     a = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 11, 12, *sep[0], 14, *sep[0]]
@@ -1084,20 +1086,26 @@ def test_separator():
     def widget_with_separator(a=a[0], b=b[0]):
         return
 
-    def get_all_itemdata(combo_box):
-        return [combo_box.itemData(index) for index in range(combo_box.count())]
+    if backend == "qt":
+        def get_all_itemdata(combo_box):
+            return [combo_box.itemData(index) for index in range(combo_box.count())]
 
-    # Count returns the number of all items including separator items
-    assert widget_with_separator.a.native.count() == 21
-    assert widget_with_separator.b.native.count() == 18
+        # Count returns the number of all items including separator items
+        assert widget_with_separator.a.native.count() == 21
+        assert widget_with_separator.b.native.count() == 18
+
+        # Separator singletons themselves are used as separator item data
+        assert get_all_itemdata(widget_with_separator.a.native) == a
+        assert get_all_itemdata(widget_with_separator.b.native) == b2
+
+    if backend == "ipynb":
+        # Separator singletons themselves are used as separator item data
+        assert widget_with_separator.a.options['choices'] == a
+        assert widget_with_separator.b.options['choices'] == b  # non-separators are not unique
 
     # Choices only returns unique, non-separator items
     assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
     assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9)
-
-    # Separator singletons themselves are used as separator item data
-    assert get_all_itemdata(widget_with_separator.a.native) == a
-    assert get_all_itemdata(widget_with_separator.b.native) == b2
 
 
 def test_float_slider_readout():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1073,8 +1073,7 @@ def test_separator():
     sep = [[Separator] * (i + 1) for i in range(4)]
     a = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 11, 12, *sep[0], 14, *sep[0]]
     b = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 6, 7, *sep[0], 9, *sep[0]]
-    a2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, 11, 12, None, 14, None)
-    b2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, None, None)
+    b2 = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], *sep[0], *sep[0]]
 
     @magicgui(
         call_button="Test Separator",
@@ -1085,10 +1084,20 @@ def test_separator():
     def widget_with_separator(a=a[0], b=b[0]):
         return
 
+    def get_all_itemdata(combo_box):
+        return [combo_box.itemData(index) for index in range(combo_box.count())]
+
+    # Count returns the number of all items including separator items
     assert widget_with_separator.a.native.count() == 21
     assert widget_with_separator.b.native.count() == 18
-    assert widget_with_separator.a.choices == a2
-    assert widget_with_separator.b.choices == b2
+
+    # Choices only returns unique, non-separator items
+    assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
+    assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9)
+
+    # Separator singletons themselves are used as separator item data
+    assert get_all_itemdata(widget_with_separator.a.native) == a
+    assert get_all_itemdata(widget_with_separator.b.native) == b2
 
 
 def test_float_slider_readout():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1080,6 +1080,9 @@ def test_separator(backend: str):
     combo_a = widgets.ComboBox(choices=a, value=a[0])
     combo_b = widgets.ComboBox(choices=b, value=b[0])
 
+    assert len(combo_a) == len(combo_a.choices)
+    assert len(combo_b) == len(combo_b.choices)
+
     if backend == "qt":
         def get_all_itemdata(combo_box):
             return [combo_box.itemData(index) for index in range(combo_box.count())]

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1059,19 +1059,20 @@ def test_literal():
     assert sel.choices == get_args(Lit)
 
 
-def test_separator_default():
-    from magicgui.types import Separator
+def test_separator_singleton():
+    from magicgui.types import Separator, _Separator
 
-    sep = Separator()
-    assert sep.thickness == 1
+    sep1 = Separator
+    sep2 = _Separator()
+    assert sep1 is sep2
 
 
 def test_separator():
     from magicgui.types import Separator
 
-    sep = [Separator(i + 1) for i in range(4)]
-    a = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 11, 12, sep[0], 14, sep[0]]
-    b = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 6, 7, sep[0], 9, sep[0]]
+    sep = [[Separator] * (i + 1) for i in range(4)]
+    a = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 11, 12, *sep[0], 14, *sep[0]]
+    b = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 6, 7, *sep[0], 9, *sep[0]]
     a2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, 11, 12, None, 14, None)
     b2 = (1, 2, None, 4, None, None, 6, 7, None, None, None, 9, None, None, None, None, None, None)
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1077,39 +1077,33 @@ def test_separator(backend: str):
     b = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], 6, 7, *sep[0], 9, *sep[0]]
     b2 = [1, 2, *sep[0], 4, *sep[1], 6, 7, *sep[2], 9, *sep[3], *sep[0], *sep[0]]
 
-    @magicgui(
-        call_button="Test Separator",
-        a={"widget_type": "ComboBox", "choices": a},
-        b={"widget_type": "ComboBox", "choices": b},
-        result_widget=True,
-    )
-    def widget_with_separator(a=a[0], b=b[0]):
-        return
+    combo_a = widgets.ComboBox(choices=a, value=a[0])
+    combo_b = widgets.ComboBox(choices=b, value=b[0])
 
     if backend == "qt":
         def get_all_itemdata(combo_box):
             return [combo_box.itemData(index) for index in range(combo_box.count())]
 
         # Count returns the number of all items including separator items
-        assert widget_with_separator.a.native.count() == 21
-        assert widget_with_separator.b.native.count() == 18
+        assert combo_a.native.count() == 21
+        assert combo_b.native.count() == 18
 
         # Separator singletons themselves are used as separator item data
-        assert get_all_itemdata(widget_with_separator.a.native) == a
-        assert get_all_itemdata(widget_with_separator.b.native) == b2
+        assert get_all_itemdata(combo_a.native) == a
+        assert get_all_itemdata(combo_b.native) == b2
 
         # Choices only returns unique, non-separator items
-        assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
-        assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9)
+        assert combo_a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
+        assert combo_b.choices == (1, 2, 4, 6, 7, 9)
 
     if backend == "ipynb":
         # Separator singletons themselves are used as separator item data
-        assert widget_with_separator.a.options['choices'] == a
-        assert widget_with_separator.b.options['choices'] == b  # items are not unique
+        assert combo_a.options['choices'] == a
+        assert combo_b.options['choices'] == b  # items are not unique
 
         # Choices only returns duplicated, non-separator items
-        assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
-        assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9, 6, 7, 9)
+        assert combo_a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
+        assert combo_b.choices == (1, 2, 4, 6, 7, 9, 6, 7, 9)
 
 
 def test_float_slider_readout():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1098,14 +1098,18 @@ def test_separator(backend: str):
         assert get_all_itemdata(widget_with_separator.a.native) == a
         assert get_all_itemdata(widget_with_separator.b.native) == b2
 
+        # Choices only returns unique, non-separator items
+        assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
+        assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9)
+
     if backend == "ipynb":
         # Separator singletons themselves are used as separator item data
         assert widget_with_separator.a.options['choices'] == a
-        assert widget_with_separator.b.options['choices'] == b  # non-separators are not unique
+        assert widget_with_separator.b.options['choices'] == b  # items are not unique
 
-    # Choices only returns unique, non-separator items
-    assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
-    assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9)
+        # Choices only returns duplicated, non-separator items
+        assert widget_with_separator.a.choices == (1, 2, 4, 6, 7, 9, 11, 12, 14)
+        assert widget_with_separator.b.choices == (1, 2, 4, 6, 7, 9, 6, 7, 9)
 
 
 def test_float_slider_readout():


### PR DESCRIPTION
Hey @tlambert03, 

I looked into `magicgui` and added a very simple mechanism for `ComboBox` to add separators by introducing a `Separator` class. Please have a look and tell me if you like it or not. Do I need to do the documentation somewhere or someone is in charge of this?

Many thanks,
Qin

### Example

By giving a list `["a", Separator(), "b"]` to magicgui for creating a dropdown list, the `ComboBox` backend go through the list, check if the data is a `Separator` and insert a separator there using `.insertSeparator()`.

I put a modified version of the example script from your repo:

```python
from magicgui import magicgui
from magicgui.types import Separator

sep = [Separator(i) for i in range(4)]
a = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 11, 12, sep[0], 14, sep[0]]
b = [1, 2, sep[0], 4, sep[1], 6, 7, sep[2], 9, sep[3], 6, 7, sep[0], 9, sep[0]]


@magicgui(call_button="Test Separator",
          a={"widget_type": "ComboBox", "choices": a},
          b={"widget_type": "ComboBox", "choices": b},
          result_widget=True)
def test_separator(a=a[0], b=b[0]):
    return


test_separator.show(run=True)
```

`a` with unique elements:

![image](https://github.com/pyapp-kit/magicgui/assets/17722010/7cafb7dc-76f2-4e16-9d39-9a8dd74f7936)

`b` with duplicates:

![image](https://github.com/pyapp-kit/magicgui/assets/17722010/9757250e-f9a1-490d-a51d-2d603b42ef29)
