### PR TITLE
Fix array data not compatible with ComboBox

### DIFF
--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -988,7 +988,7 @@ class ComboBox(QBaseValueWidget, protocols.CategoricalWidgetProtocol):
         return tuple(
             (self._qwidget.itemText(i), self._qwidget.itemData(i))
             for i in range(self._qwidget.count())
-            if self._qwidget.itemData(i) != Separator
+            if self._qwidget.itemData(i) is not Separator
         )
 
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -287,6 +287,20 @@ def test_unhashable_choice_data():
     combo.close()
 
 
+def test_ambiguous_eq_choice_data():
+    """Test that providing choice data with an ambiguous equal operation is ok."""
+    import numpy as np
+    
+    combo = widgets.ComboBox()
+    assert not combo.choices
+    combo.choices = (("a", np.array([0, 0, 0])), ("b", np.array([1, 2, 3])))
+    assert len(combo.choices) == 2
+    assert np.all(combo.choices[0] == [0, 0, 0])
+    assert np.all(combo.choices[1] == [1, 2, 3])
+
+    combo.close()
+
+
 def test_bound_values():
     """Test that we can bind a "permanent" value override to a parameter."""
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -290,7 +290,7 @@ def test_unhashable_choice_data():
 def test_ambiguous_eq_choice_data():
     """Test that providing choice data with an ambiguous equal operation is ok."""
     import numpy as np
-    
+
     combo = widgets.ComboBox()
     assert not combo.choices
     combo.choices = (("a", np.array([0, 0, 0])), ("b", np.array([1, 2, 3])))


### PR DESCRIPTION
After ComboBox supported separators, it does not allow `ndarray` and `DataFrame` as the choices anymore because of the comparison `!= Separator` (raises "ValueError: The truth value of a DataFrame is ambiguous."). 
This PR fixes it.