### PR TITLE
chore: Upload pydantic1 coverage with all other coverages

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -e .
-          python -m pip install pytest 'pydantic<2' attrs pyqt6
+          python -m pip install pytest 'pydantic<2' attrs pyqt6 coverage
 
       - name: Test
         uses: aganders3/headless-gui@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
   test-pydantic1:
     name: Test pydantic1

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -67,13 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-
-  upload_coverage:
-    if: always()
-    needs: [test, test-min-reqs]
-    uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
-    secrets: inherit
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
   test-pydantic1:
     name: Test pydantic1
@@ -90,16 +84,28 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -e .
-          python -m pip install pytest 'pydantic<2' attrs pytest-cov pyqt6
+          python -m pip install pytest 'pydantic<2' attrs pyqt6
 
       - name: Test
         uses: aganders3/headless-gui@v2
         with:
-          run: pytest tests/test_ui_field.py -v --color=yes --cov=magicgui --cov-report=xml
+          run: coverage run -p -m pytest tests/test_ui_field.py -v --color=yes
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: covreport-pydantic1
+          path: ./.coverage*
 
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  upload_coverage:
+    if: always()
+    needs: [test, test-min-reqs, test-pydantic1]
+    uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
+    secrets: inherit
 
   test-dependents:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -97,10 +97,6 @@ jobs:
           name: covreport-pydantic1
           path: ./.coverage*
 
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   upload_coverage:
     if: always()
     needs: [test, test-min-reqs, test-pydantic1]


### PR DESCRIPTION
When I was working on #658 I spot that first message from codecov shows big drop of coverage. I was confused until I found that it is triggered by upload coverage of pydantic1 steep in separate. 

This PR unifies coverage upload. 