### PR TITLE
Nested pydantic model containers

### DIFF
--- a/src/magicgui/schema/_guiclass.py
+++ b/src/magicgui/schema/_guiclass.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import TypeGuard
 
+    from magicgui.types import NestedValueWidgets
+
     # fmt: off
     class GuiClassProtocol(Protocol):
         """Protocol for a guiclass."""
@@ -206,7 +208,7 @@ class GuiBuilder:
 
     def __get__(
         self, instance: object | None, owner: type
-    ) -> ContainerWidget[ValueWidget]:
+    ) -> ContainerWidget[NestedValueWidgets]:
         wdg = build_widget(owner if instance is None else instance)
 
         # look for @button-decorated methods

--- a/src/magicgui/schema/_ui_field.py
+++ b/src/magicgui/schema/_ui_field.py
@@ -441,7 +441,20 @@ class UiField(Generic[T]):
             opts["min"] = d["exclusive_minimum"] + m
 
         value = value if value is not Undefined else self.get_default()  # type: ignore
-        cls, kwargs = get_widget_class(value=value, annotation=self.type, options=opts)
+        try:
+            cls, kwargs = get_widget_class(
+                value=value, annotation=self.type, options=opts
+            )
+        except ValueError:
+            try:
+                wdg = build_widget(self.type)
+                wdg.label = self.name
+                return wdg
+            except TypeError as e:
+                raise TypeError(
+                    f"Could not create widget for field {self.name!r} "
+                    f"with value {value!r}"
+                ) from e
         return cls(**kwargs)  # type: ignore
 
 

--- a/src/magicgui/types.py
+++ b/src/magicgui/types.py
@@ -10,7 +10,12 @@ from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
-    from magicgui.widgets.bases import CategoricalWidget, Widget
+    from magicgui.widgets.bases import (
+        CategoricalWidget,
+        ContainerWidget,
+        ValueWidget,
+        Widget,
+    )
     from magicgui.widgets.protocols import WidgetProtocol
 
 
@@ -28,6 +33,9 @@ WidgetClass = Union["type[Widget]", "type[WidgetProtocol]"]
 WidgetRef = Union[str, WidgetClass]
 #: A :attr:`WidgetClass` (or a string representation of one) and a dict of kwargs
 WidgetTuple = Tuple[WidgetRef, Dict[str, Any]]
+#: A [`ValueWidget`][magicgui.widgets.ValueWidget] class or a
+#: [`ContainerWidget`][magicgui.widgets.ContainerWidget] class for nesting those
+NestedValueWidgets = Union["ValueWidget", "ContainerWidget[NestedValueWidgets]"]
 #: An iterable that can be used as a valid argument for widget ``choices``
 ChoicesIterable = Union[Iterable[Tuple[str, Any]], Iterable[Any]]
 #: An callback that can be used as a valid argument for widget ``choices``.  It takes

--- a/src/magicgui/widgets/bases/_container_widget.py
+++ b/src/magicgui/widgets/bases/_container_widget.py
@@ -335,11 +335,13 @@ class ContainerWidget(Widget, _OrientationMixin, MutableSequence[WidgetVar]):
 
     def asdict(self) -> dict[str, Any]:
         """Return state of widget as dict."""
-        return {
-            w.name: getattr(w, "value", None)
-            for w in self._list
-            if w.name and not w.gui_only
-        }
+        ret = {}
+        for w in self._list:
+            if w.name and not w.gui_only:
+                ret[w.name] = getattr(w, "value", None)
+            if isinstance(w, ContainerWidget):
+                ret[w.label] = w.asdict()
+        return ret
 
     def update(
         self,


### PR DESCRIPTION
Hi @tlambert03,
when using nested pydantic models, I found [this post](https://forum.image.sc/t/building-a-napari-widget-from-a-pydantic-model/90257/11) on how to add a simple way of nesting widgets/containers. When trying to use the values, I needed to modify `asdict()` as well. Although there might be a reason you didn't just implement it already when answering the post (probably due to #317), I thought I'd make a pull request just in case.

Notably, some things are missing:
* Proper test e.g. for getting nested values from `ValueWidget`s and `ContainerWidget`s - as I didn't really know where to start
* QGroupBox option as mentioned in #317 

Also, I tried my best with the types, but I probably don't oversee the grand scheme of things... 😅 

I hope it's helpful, but I'm aware it might not be, so feel free to just close 😄 

Thanks for having a look!