### PR TITLE
fix: use default font from application instead of system default

### DIFF
--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -15,7 +15,6 @@ import superqt
 from qtpy import QtWidgets as QtW
 from qtpy.QtCore import QEvent, QObject, QSize, Qt, Signal
 from qtpy.QtGui import (
-    QFont,
     QFontMetrics,
     QIcon,
     QImage,
@@ -1358,7 +1357,8 @@ def get_text_width(text: str) -> int:
         doc.setHtml(text)
         return math.ceil(doc.size().width())
     else:
-        fm = QFontMetrics(QFont("", 0))
+        font = QtW.QApplication.font()
+        fm = QFontMetrics(font)
         return fm.boundingRect(text).width() + 5
 
 


### PR DESCRIPTION
This is a change proposed to solve the warning issue experienced on Windows with napari. See https://github.com/napari/napari/issues/8877 for a complete description of it.