### PR TITLE
chore: Use `dependency-group` for napari in ci test

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -141,11 +141,12 @@ jobs:
     secrets: inherit
 
   test-dependents:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@main
     with:
       dependency-repo: ${{ matrix.package }}
       dependency-ref: ${{ matrix.package-version }}
-      dependency-extras: ${{ matrix.package-extras || 'testing' }}
+      dependency-extras: ${{ matrix.package-extras || '' }}
+      dependency-group: ${{ matrix.package-group || '' }}
       qt: pyqt5
       python-version: "3.10"
       post-install-cmd: "python -m pip install pytest-pretty lxml_html_clean" # just for napari
@@ -155,11 +156,14 @@ jobs:
       matrix:
         include:
           - package: napari/napari
+            package-group: testing
             pytest-args: src/napari/_tests/test_magicgui.py --import-mode=importlib
           - package: napari/napari
             package-version: "v0.4.19.post1"
+            package-extras: testing
             pytest-args: napari/_tests/test_magicgui.py
           - package: hanjinliu/magic-class
+            package-extras: testing
           - package: 4DNucleome/PartSeg
             package-extras: test
             pytest-args: package/tests/test_PartSeg/test_napari_widgets.py

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -148,7 +148,7 @@ jobs:
       dependency-extras: ${{ matrix.package-extras || '' }}
       dependency-group: ${{ matrix.package-group || '' }}
       qt: pyqt5
-      python-version: "3.10"
+      python-version: ${{ matrix.python-version || '3.10' }}
       post-install-cmd: "python -m pip install pytest-pretty lxml_html_clean" # just for napari
       pytest-args: ${{ matrix.pytest-args }}
     strategy:
@@ -156,6 +156,7 @@ jobs:
       matrix:
         include:
           - package: napari/napari
+            python-version: "3.13"
             package-group: testing
             pytest-args: src/napari/_tests/test_magicgui.py --import-mode=importlib
           - package: napari/napari


### PR DESCRIPTION
napari/napari#8704

Uses a matrix value or blank for either `dependency-extras` or `dependency-group` in the test_dependents ci.