### PR TITLE
Don't parameterize tests using non-Collection iterables

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -200,7 +200,7 @@ def test_dataview_getitem(index):
     assert np.allclose(table.data[index], data[index])
 
 
-@pytest.mark.parametrize("index, value", zip(INDICES, VALUES))
+@pytest.mark.parametrize("index, value", list(zip(INDICES, VALUES)))
 def test_dataview_setitem(index, value):
     """Test that table.data can be indexed like a numpy array."""
     np = pytest.importorskip("numpy")


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize.