### PR TITLE
fix: Table.data support for negative indices

### DIFF
--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -1520,13 +1520,20 @@ class Table(QBaseWidget, protocols.TableWidgetProtocol):
             normalized_row = row + num_rows
         else:
             normalized_row = row
-        if col < 0: 
+        if col < 0:
             normalized_col = col + num_cols
         else:
             normalized_col = col
-        # Qt will not raise an error for attempting to index into an invalid column, but normal Pyhton does.
-        if normalized_row >= num_rows or normalized_col >= num_cols:
-            raise IndexError(f"Index ({row}, {col}) is out of bounds for table of shape ({num_rows}, {num_cols}).")
+        # Qt will not raise an error for attempting to index into an invalid cell, but normal Python does.
+        if (
+            normalized_row < 0
+            or normalized_col < 0
+            or normalized_row >= num_rows
+            or normalized_col >= num_cols
+        ):
+            raise IndexError(
+                f"Index ({row}, {col}) is out of bounds for table of shape ({num_rows}, {num_cols})."
+            )
         return normalized_row, normalized_col
 
     def _mgui_get_cell(self, row: int, col: int) -> Any:

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -1524,7 +1524,8 @@ class Table(QBaseWidget, protocols.TableWidgetProtocol):
             normalized_col = col + num_cols
         else:
             normalized_col = col
-        # Qt will not raise an error for attempting to index into an invalid cell, but normal Python does.
+        # Qt will not raise an error for attempting to index into an invalid cell, but
+        # normal Python does.
         if (
             normalized_row < 0
             or normalized_col < 0
@@ -1532,7 +1533,8 @@ class Table(QBaseWidget, protocols.TableWidgetProtocol):
             or normalized_col >= num_cols
         ):
             raise IndexError(
-                f"Index ({row}, {col}) is out of bounds for table of shape ({num_rows}, {num_cols})."
+                f"Index ({row}, {col}) is out of bounds for table of shape"
+                f" ({num_rows}, {num_cols})."
             )
         return normalized_row, normalized_col
 

--- a/src/magicgui/backends/_qtpy/widgets.py
+++ b/src/magicgui/backends/_qtpy/widgets.py
@@ -1512,8 +1512,26 @@ class Table(QBaseWidget, protocols.TableWidgetProtocol):
     def _mgui_remove_column(self, column: int) -> None:
         self._qwidget.removeColumn(column)
 
+    def _normalize_cell_index(self, row: int, col: int) -> tuple[int, int]:
+        num_rows = self._mgui_get_row_count()
+        num_cols = self._mgui_get_column_count()
+        # Offset negative indices because Qt doesn't natively support them
+        if row < 0:
+            normalized_row = row + num_rows
+        else:
+            normalized_row = row
+        if col < 0: 
+            normalized_col = col + num_cols
+        else:
+            normalized_col = col
+        # Qt will not raise an error for attempting to index into an invalid column, but normal Pyhton does.
+        if normalized_row >= num_rows or normalized_col >= num_cols:
+            raise IndexError(f"Index ({row}, {col}) is out of bounds for table of shape ({num_rows}, {num_cols}).")
+        return normalized_row, normalized_col
+
     def _mgui_get_cell(self, row: int, col: int) -> Any:
         """Get current value of the widget."""
+        row, col = self._normalize_cell_index(row, col)
         item = self._qwidget.item(row, col)
         if item:
             return item.data(_DATA_ROLE)
@@ -1523,6 +1541,7 @@ class Table(QBaseWidget, protocols.TableWidgetProtocol):
 
     def _mgui_set_cell(self, row: int, col: int, value: Any) -> None:
         """Set current value of the widget."""
+        row, col = self._normalize_cell_index(row, col)
         if value is None:
             self._qwidget.setItem(row, col, None)
             self._qwidget.removeCellWidget(row, col)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -216,14 +216,11 @@ def test_dataview_setitem(index, value):
     data[index] = value
     assert np.allclose(table.data.to_list(), data)
 
-INVLAID_INDICES = (
-    (6, 0),
-    (0, 4),
-    (-7, 0),
-    (0, -5)
-)
 
-@pytest.mark.parametrize("index", INVLAID_INDICES)
+INVALID_INDICES = ((6, 0), (0, 4), (-7, 0), (0, -5))
+
+
+@pytest.mark.parametrize("index", INVALID_INDICES)
 def test_dataview_getitem_invalid_index(index):
     """Test that invalid cell indices raise IndexError."""
     np = pytest.importorskip("numpy")
@@ -234,7 +231,7 @@ def test_dataview_getitem_invalid_index(index):
         table.data[index]
 
 
-@pytest.mark.parametrize("index", INVLAID_INDICES)
+@pytest.mark.parametrize("index", INVALID_INDICES)
 def test_dataview_setitem_invalid_index(index):
     """Test that invalid cell indices raise IndexError."""
     np = pytest.importorskip("numpy")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -200,7 +200,7 @@ def test_dataview_getitem(index):
     assert np.allclose(table.data[index], data[index])
 
 
-@pytest.mark.parametrize("index, value", zip(INDICES, VALUES))
+@pytest.mark.parametrize("index, value", tuple(zip(INDICES, VALUES)))
 def test_dataview_setitem(index, value):
     """Test that table.data can be indexed like a numpy array."""
     np = pytest.importorskip("numpy")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -216,12 +216,9 @@ def test_dataview_setitem(index, value):
     data[index] = value
     assert np.allclose(table.data.to_list(), data)
 
-INVLAID_INDICES = (
-    (6, 0),
-    (0, 4),
-    (-7, 0),
-    (0, -5)
-)
+
+INVLAID_INDICES = ((6, 0), (0, 4), (-7, 0), (0, -5))
+
 
 @pytest.mark.parametrize("index", INVLAID_INDICES)
 def test_dataview_getitem_invalid_index(index):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -171,6 +171,8 @@ def test_table_from_numpy():
 INDICES = (
     1,
     (2, 2),
+    -2,
+    (-1, -1),
     (slice(None), 2),
     (slice(None), slice(None)),
     (slice(1, 3), slice(3)),
@@ -181,6 +183,8 @@ INDICES = (
 VALUES = (
     (7,) * 4,
     6,
+    (14,) * 4,
+    25,
     (7,) * 6,
     [[1] * 4] * 6,
     [[1] * 3] * 2,
@@ -211,6 +215,34 @@ def test_dataview_setitem(index, value):
     assert not np.allclose(table.data.to_list(), data)
     data[index] = value
     assert np.allclose(table.data.to_list(), data)
+
+INVLAID_INDICES = (
+    (6, 0),
+    (0, 4),
+    (-7, 0),
+    (0, -5)
+)
+
+@pytest.mark.parametrize("index", INVLAID_INDICES)
+def test_dataview_getitem_invalid_index(index):
+    """Test that invalid cell indices raise IndexError."""
+    np = pytest.importorskip("numpy")
+    data = np.arange(24).reshape(6, 4)
+
+    table = Table(value=data)
+    with pytest.raises(IndexError):
+        table.data[index]
+
+
+@pytest.mark.parametrize("index", INVLAID_INDICES)
+def test_dataview_setitem_invalid_index(index):
+    """Test that invalid cell indices raise IndexError."""
+    np = pytest.importorskip("numpy")
+    data = np.arange(24).reshape(6, 4)
+
+    table = Table(value=data)
+    with pytest.raises(IndexError):
+        table.data[index] = 999
 
 
 def test_dataview_delitem():


### PR DESCRIPTION
Qt native Table `_mgui_get_cell()` and `_mgui_set_cell()` now support negative indices and will raise an `IndexError` if invalid indices are specified.

Previously, getting or setting to an invalid index would do nothing. Raising an `IndexError` is probably more useful, but may break some existing code.

Fixes #735.