### PR TITLE
fix: bind magic factories as method descriptors

### DIFF
--- a/src/magicgui/type_map/_magicgui.py
+++ b/src/magicgui/type_map/_magicgui.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from functools import partial
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar, cast
 
 from magicgui.type_map._type_map import TypeMap
 from magicgui.widgets import FunctionGui
@@ -82,6 +82,28 @@ class MagicFactory(partial, Generic[_FGuiVar]):
             if v not in (MAGICGUI_PARAMS[k].default, {})
         ]
         return f"MagicFactory({', '.join(args)})"
+
+    def __get__(self, obj: Any, objtype: type | None = None) -> MagicFactory[_FGuiVar]:
+        """Bind the factory's function when accessed as a method descriptor."""
+        if obj is None:
+            return self
+
+        factory_kwargs = self.keywords.copy()
+        function = factory_kwargs.pop("function")
+        function_get = getattr(function, "__get__", None)
+        bound_function = (
+            function_get(obj, objtype)
+            if function_get is not None
+            else partial(function, obj)
+        )
+        return type(self)(
+            bound_function,
+            *self.args,
+            magic_class=cast("type[_FGuiVar]", self.func),
+            widget_init=self._widget_init,
+            type_map=self._type_map,
+            **factory_kwargs,
+        )
 
     # TODO: annotate args and kwargs here so that
     # calling a MagicFactory instance gives proper mypy hints

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,3 +1,6 @@
+import gc
+import weakref
+
 import pytest
 from psygnal import EmitLoopError
 
@@ -46,6 +49,50 @@ def test_magic_factory_reuse():
 
     widget_b = factory()
     assert isinstance(widget_b.x, ComboBox)
+
+
+def test_magic_factory_method_descriptor():
+    initialized = []
+
+    def widget_init(widget):
+        initialized.append(widget)
+
+    class Example:
+        def __init__(self, value):
+            self.value = value
+
+        @magic_factory(call_button=True, widget_init=widget_init)
+        def factory(self, suffix: str = ""):
+            return f"{self.value}{suffix}"
+
+    first = Example("first")
+    second = Example("second")
+    first_widget = first.factory()
+    second_widget = second.factory()
+
+    assert Example.factory is Example.__dict__["factory"]
+    assert first_widget.call_button
+    assert first_widget() == "first"
+    assert second_widget(suffix="!") == "second!"
+    assert initialized == [first_widget, second_widget]
+
+
+def test_magic_factory_method_descriptor_does_not_retain_instance():
+    class Example:
+        @magic_factory
+        def factory(self):
+            return self
+
+    instance = Example()
+    instance_ref = weakref.ref(instance)
+    bound_factory = instance.factory
+
+    del instance
+    assert instance_ref() is not None
+
+    del bound_factory
+    gc.collect()
+    assert instance_ref() is None
 
 
 def test_magic_factory_repr():


### PR DESCRIPTION
## Summary
- bind the decorated function when a `MagicFactory` is accessed through an instance
- preserve class-level access, factory options, `widget_init`, and the originating type map
- cover independent instance binding and ensure a temporary bound factory does not retain its instance

Fixes #733

## Tests
- Python 3.12.9: `python -m pytest -q` (`330 passed, 51 skipped, 13 xfailed`)
- Python 3.14.6: `python -m pytest tests/test_factory.py -q` (`12 passed`)
- `pre-commit run --all-files`
- `mypy src/magicgui/type_map/_magicgui.py`