### PR TITLE
test: deterministically tear down example widgets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,15 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+# hatchling 1.32 emits core metadata 2.5 by default, which twine (as run by
+# build-and-inspect-python-package) rejects.  TODO: remove once twine there
+# accepts metadata 2.5.
+[tool.hatch.build.targets.sdist]
+core-metadata-version = "2.4"
+
+[tool.hatch.build.targets.wheel]
+core-metadata-version = "2.4"
+
 # https://peps.python.org/pep-0621/
 [project]
 name = "magicgui"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,11 @@ third-party-support = [
     "toolz>=1.0.0",
 ]
 test-min = ["pytest>=8.4.0", "pytest-cov >=6.1", "pytest-mypy-plugins>=3.1"]
-test-qt = [{ include-group = "test-min" }, "pytest-qt ==4.4.0"]
+# pytest-qt >=4.5 fixes SystemError/TimeoutError in qtbot.waitSignal with
+# recent PySide6 (pytest-dev/pytest-qt#552), but drops PySide2 support --
+# so the pyside2 group uses the legacy pin (see [tool.uv] conflicts below)
+test-qt = [{ include-group = "test-min" }, "pytest-qt>=4.5.0"]
+test-qt-legacy = [{ include-group = "test-min" }, "pytest-qt==4.4.0"]
 test = [
     "magicgui[tqdm,jupyter,image,quantity]",
     { include-group = "test-min" },
@@ -83,7 +87,7 @@ test = [
 ]
 pyqt5 = ["magicgui[pyqt5]", { include-group = "test-qt" }]
 pyqt6 = ["magicgui[pyqt6]", { include-group = "test-qt" }]
-pyside2 = ["magicgui[pyside2]", { include-group = "test-qt" }, "numpy<2; python_version < '3.13'"]
+pyside2 = ["magicgui[pyside2]", { include-group = "test-qt-legacy" }, "numpy<2; python_version < '3.13'"]
 pyside6 = ["magicgui[pyside6]", { include-group = "test-qt" }]
 dev = [
     { include-group = "test" },
@@ -115,6 +119,10 @@ docs = [
     "ipywidgets >=8.0.0",
     "ipykernel>=6.29.5",
 ]
+
+[tool.uv]
+# the two pytest-qt pins are mutually exclusive; no environment installs both
+conflicts = [[{ group = "test-qt" }, { group = "test-qt-legacy" }]]
 
 [tool.uv.sources]
 magicgui = { workspace = true }

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -404,7 +404,7 @@ class FileEdit(ValuedContainerWidget[Union[Path, tuple[Path, ...], None]]):
         self,
         mode: FileDialogMode = FileDialogMode.EXISTING_FILE,
         filter: str | None = None,
-        value: Path | tuple[Path, ...] | None | _Undefined = Undefined,
+        value: Path | tuple[Path, ...] | _Undefined | None = Undefined,
         **kwargs: Unpack[ValuedContainerKwargs],
     ) -> None:
         # use empty string as a null value

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,8 +1,10 @@
+import gc
 import runpy
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from qtpy.QtCore import QCoreApplication, QEvent
 from qtpy.QtWidgets import QApplication
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "docs" / "examples"
@@ -34,3 +36,24 @@ def test_example(qapp: QApplication, example: Path) -> None:
                 # dependency it requires, that's fine
                 pytest.xfail(str(e))
             raise
+        finally:
+            # Deterministically tear down whatever the example created.  The
+            # namespace returned by runpy is discarded, so the example's
+            # widgets are otherwise garbage-collected at an arbitrary later
+            # point -- and a still-visible widget whose C++ side is deleted
+            # during event processing can receive a paintEvent mid-deletion,
+            # which aborts the process on Windows/PyQt5 with
+            # "RuntimeError: wrapped C/C++ object ... has been deleted"
+            # (seen intermittently in superqt's QRangeSlider paintEvent for
+            # demo_widgets/range_slider.py).  Hide everything first so
+            # nothing paints, then destroy the native widgets while they are
+            # hidden (which also stops their timers), then collect whatever
+            # is left while flushing events.
+            for widget in qapp.topLevelWidgets():
+                widget.close()
+                widget.deleteLater()
+            # NB: processEvents() does not dispatch DeferredDelete events
+            QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+            qapp.processEvents()
+            gc.collect()
+            qapp.processEvents()

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -935,7 +935,7 @@ def test_no_order():
     register_type(Union[int, None], return_callback=mock)
 
     @magicgui
-    def func() -> Union[None, int]:
+    def func() -> Union[int, None]:
         return 1
 
     func()


### PR DESCRIPTION
CIs seem to be failing in all PRs. Based on (painful) experience with PyVistaQt, mne-qt-browser, etc. a reasonable fix is to make sure windows are closed and torn down at the end of every test (rather than "whenever gc.collect() decides to run"). Otherwise, a still-visible widget whose C++ side is deleted mid-event-loop can receive a paintEvent during deletion, which leads to a segfault.

This should hopefully fix CIs. Changes drafted by Claude Fable 5 but reviewed / iterated / understood be me.