### PR TITLE
ci(pre-commit): autoupdate hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: '0.26'
     hooks:
       - id: validate-pyproject
 
@@ -16,20 +16,20 @@ repos:
         files: "^\\.github/workflows/.*\\.ya?ml$"
 
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.48.0
+    rev: v1.49.0
     hooks:
       - id: typos
         args: [--force-exclude] # omitting --write-changes
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.4
     hooks:
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: "^src/"

--- a/src/magicgui/widgets/_concrete.py
+++ b/src/magicgui/widgets/_concrete.py
@@ -404,7 +404,7 @@ class FileEdit(ValuedContainerWidget[Union[Path, tuple[Path, ...], None]]):
         self,
         mode: FileDialogMode = FileDialogMode.EXISTING_FILE,
         filter: str | None = None,
-        value: Path | tuple[Path, ...] | None | _Undefined = Undefined,
+        value: Path | tuple[Path, ...] | _Undefined | None = Undefined,
         **kwargs: Unpack[ValuedContainerKwargs],
     ) -> None:
         # use empty string as a null value

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -934,8 +934,10 @@ def test_no_order():
 
     register_type(Union[int, None], return_callback=mock)
 
+    # registration above used Union[int, None]; annotating with the reversed
+    # order is the whole point of this test, so RUF036 must not "fix" it
     @magicgui
-    def func() -> Union[None, int]:  # noqa: RUF036  # deliberately reversed
+    def func() -> Union[None, int]:  # noqa: RUF036
         return 1
 
     func()

--- a/tests/test_magicgui.py
+++ b/tests/test_magicgui.py
@@ -935,7 +935,7 @@ def test_no_order():
     register_type(Union[int, None], return_callback=mock)
 
     @magicgui
-    def func() -> Union[None, int]:
+    def func() -> Union[None, int]:  # noqa: RUF036  # deliberately reversed
         return 1
 
     func()


### PR DESCRIPTION
Follow-up to #728: re-ran `prek autoupdate` on current `main`.

- validate-pyproject `v0.25` → `0.26`
- typos `v1.48.0` → `v1.49.0`
- ruff `v0.16.1` → `v0.16.4`
- mypy `v2.3.0` → `v2.3.1`

ruff 0.16.4 adds a fix for [RUF036] (`None` not at the end of a type union),
which hits two places:

- `_concrete.py` — applied as-is.
- `tests/test_magicgui.py::test_no_order` — reverted and `noqa`'d, since the
  reversed `Union[None, int]` is precisely what that test is checking.

All hooks pass, and the suite passes locally on both PyQt6 and PySide6.

[RUF036]: https://docs.astral.sh/ruff/rules/none-not-at-end-of-union/

🤖 Generated with [Claude Code](https://claude.com/claude-code)